### PR TITLE
feat: add extra_params pass-through for provider-specific SLM params

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-ai-gateway"
+  "feature_directory": "specs/006-slm-model-params"
 }

--- a/.specify/memory/impl-context.md
+++ b/.specify/memory/impl-context.md
@@ -1,4 +1,4 @@
-# Implementation Context — AI Gateway
+# Implementation Context — SLM Model Params (006)
 
 ## Grounding Chain
 - .specify/memory/verified-sources.md: OK
@@ -7,33 +7,26 @@
 
 ## Runtime Environment
 - RUNTIME: python 3.12.3
-- RUNTIME: node v24.13.0 (not used)
-- RUNTIME: npm 11.6.2 (not used)
-- RUNTIME: rustc not found (not used)
-- RUNTIME: go not found (not used)
 
 ## Installed Packages (relevant)
-- litellm==1.89.4 (NOT in pyproject.toml — T001 needed)
-- httpx==0.28.1 ✅
 - pydantic==2.13.4 ✅
-- typer==0.26.7 ✅
-- rich==15.0.0 ✅
-- PyYAML==6.0.3 ✅
-- platformdirs==4.10.0 (via pyproject.toml)
+- pyyaml==6.0.3 ✅
+- litellm==1.90.1 ✅
 
 ## Plan vs Runtime
-- litellm planned NEW dep | installed 1.89.4 but NOT in pyproject.toml → T001 needed
-- All other planned deps are already in pyproject.toml → MATCH
+- Python 3.12 matches plan ✅
+- Pydantic 2.x matches plan ✅
+- All planned deps present ✅
 
 ## Filesystem Delta (since task-context.md)
-- src/openreview_cli/gateway/ exists with stale __pycache__/ only → clean slate
-- specs/005-ai-gateway/ exists with all artifacts → NEW
+- No structural changes since task-context.md snapshot
+- All gateway files present: models.py, router.py, models.json, config/loader.py
 
 ## Tasks Baseline
-- TASKS TOTAL: 38
-- TASKS COMPLETE [X]: 29
-- TASKS PENDING [ ]: 9
-- FIRST PENDING: T030 — Wire redact_key utility into gateway logging and error output
+- TASKS TOTAL: 17
+- TASKS COMPLETE [X]: 16
+- TASKS PENDING [ ]: 1
+- FIRST PENDING: T017 — Update spec.md Edge Cases entry for non-dict extra_params
 
 ## Implementation Clearance
 STATUS: CLEAR — implementation may proceed

--- a/.specify/memory/verified-sources.md
+++ b/.specify/memory/verified-sources.md
@@ -1,123 +1,33 @@
-# Verified Sources — AI Gateway (Phase 4)
+# Verified Sources — 006-slm-model-params
 
 **Generated**: 2026-07-01
-**Feature**: specs/005-ai-gateway
 
 ## Dependencies
 
-ITEM: litellm
-SOURCE: https://github.com/berriai/litellm | https://pypi.org/project/litellm/
-VERSION: 1.81.9-stable (latest stable as of 2026-06-30)
+ITEM: LiteLLM
+SOURCE: https://docs.litellm.ai/docs/completion/provider_specific_params
+VERSION: 1.90.1 (installed)
 KEY FACTS:
-- `litellm.completion(model="provider/model", messages=[...])` — unified chat completion
-- `litellm.embedding(model="provider/model", input=[...])` — unified embedding
-- `litellm.rerank(model="provider/model", query=..., documents=[...], top_n=N)` — unified rerank
-- `litellm.completion_cost(response)` — returns cost in USD from response object
-- Response object contains `usage.prompt_tokens`, `usage.completion_tokens`, `usage.total_tokens`
-- Ollama models prefixed `ollama/model_name`, api_base defaults to `http://localhost:11434`
-- Supports `fallbacks` parameter for automatic model fallback
-- Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc.
+- LiteLLM forwards any non-OpenAI parameter as a provider-specific kwarg to the underlying provider
+- Ollama provider supported — uses `ollama/` prefix (e.g. `ollama/llama2`)
+- Provider-specific params work via SDK, YAML config, and `extra_body` in proxy mode
+- `completion(**kwargs)` signature accepts arbitrary kwargs and routes them through
+- Embedding function follows the same pattern
 STATUS: CONFIRMED
 
-ITEM: httpx
-SOURCE: https://pypi.org/project/httpx/
-VERSION: >=0.28.1 (pinned in pyproject.toml)
+ITEM: Pydantic
+SOURCE: https://docs.pydantic.dev/latest/
+VERSION: 2.13.4 (installed)
 KEY FACTS:
-- Already a runtime dependency, used for HTTP requests
-- Used by the registry refresh to fetch models.json from GitHub
+- `dict[str, Any]` fields supported natively in BaseModel
+- Optional fields with `None` default via `field: dict[str, Any] | None = None`
+- Nested dicts serialize/deserialize correctly via JSON
 STATUS: CONFIRMED
 
-ITEM: pydantic
-SOURCE: https://pypi.org/project/pydantic/
-VERSION: >=2.13.4 (pinned in pyproject.toml)
+ITEM: Python stdlib logging
+SOURCE: https://docs.python.org/3.12/library/logging.html
+VERSION: Python 3.12.3 (stdlib)
 KEY FACTS:
-- Already a runtime dependency
-- Used extensively in config/loader.py for GatewayConfig, ModelSlot, etc.
-- BaseModel with field_validator for config validation
-STATUS: CONFIRMED
-
-ITEM: typer
-SOURCE: https://pypi.org/project/typer/
-VERSION: >=0.26.7 (pinned in pyproject.toml)
-KEY FACTS:
-- Already a runtime dependency
-- CLI framework, used for all subcommands in app.py
-- Supports nested Typer apps (client_app, config_app, pii_app already exist)
-STATUS: CONFIRMED
-
-ITEM: rich
-SOURCE: https://pypi.org/project/rich/
-VERSION: >=15.0.0 (pinned in pyproject.toml)
-KEY FACTS:
-- Already a runtime dependency
-- Used for Table output in CLI commands
-- Console() for styled output
-STATUS: CONFIRMED
-
-ITEM: PyYAML
-SOURCE: https://pypi.org/project/pyyaml/
-VERSION: >=6.0.3 (pinned in pyproject.toml)
-KEY FACTS:
-- Already a runtime dependency
-- Used in config/loader.py for yaml.safe_load / yaml.safe_dump
-STATUS: CONFIRMED
-
-ITEM: platformdirs
-SOURCE: https://pypi.org/project/platformdirs/
-VERSION: >=4.10.0 (pinned in pyproject.toml)
-KEY FACTS:
-- Already a runtime dependency
-- Used in config/paths.py for user_config_dir, user_data_dir, user_log_dir
-STATUS: CONFIRMED
-
-ITEM: sqlite3
-SOURCE: Python stdlib
-VERSION: Built-in (Python 3.12)
-KEY FACTS:
-- Used in storage/database.py for all DB operations
-- WAL mode, foreign keys enabled
-- cost_logs table already exists in 001_initial.sql
-STATUS: CONFIRMED
-
-## Existing Infrastructure (from codebase scan)
-
-ITEM: config/loader.py GatewayConfig
-SOURCE: src/openreview_cli/config/loader.py
-VERSION: N/A (local code)
-KEY FACTS:
-- GatewayModels Pydantic model already defines 5 slots: reasoning, extraction, embedding, reranking, graph
-- ModelSlot has primary, fallback, params (temperature, max_tokens)
-- EmbeddingSlot and RerankingSlot are simpler (primary only)
-- FallbackConfig has retries, retry_delay, timeout, on_failure
-- CostLimits has per_review_cents, daily_cents
-- model_registry_refresh_days = 7
-STATUS: CONFIRMED
-
-ITEM: config/auth.py
-SOURCE: src/openreview_cli/config/auth.py
-VERSION: N/A (local code)
-KEY FACTS:
-- load_auth() reads auth.json, overlays env vars
-- key_to_env() maps provider names to env var names (openai→OPENAI_API_KEY, etc.)
-- ensure_auth() creates auth.json with 600 permissions
-- _check_permissions() warns and fixes world-readable auth.json
-STATUS: CONFIRMED
-
-ITEM: storage/database.py cost_logs
-SOURCE: src/openreview_cli/storage/database.py
-VERSION: N/A (local code)
-KEY FACTS:
-- log_cost() inserts into cost_logs table
-- check_daily_limit() sums cost_cents for today
-- check_review_limit() sums cost_cents for a review_id
-- cost_logs schema: id, review_id, model, provider, prompt_tokens, completion_tokens, cost_cents, created_at
-STATUS: CONFIRMED
-
-ITEM: config/paths.py
-SOURCE: src/openreview_cli/config/paths.py
-VERSION: N/A (local code)
-KEY FACTS:
-- get_config_dir() → ~/.config/openreview/ (via platformdirs)
-- get_data_dir() → user data dir
-- get_log_dir() → user log dir
+- `logger.debug()` and `logger.warning()` are the methods needed
+- No new imports required — already used in `router.py`
 STATUS: CONFIRMED

--- a/README.md
+++ b/README.md
@@ -13,20 +13,21 @@ a custom playbook, and produces a structured memo of findings.
 
 ## Status
 
-Pre-alpha. All 38 Phase 9 AI Gateway tasks converged across config + storage
-foundation, document parsing, PII stripping (Phase 3), and AI provider gateway
-(Phase 4). The package is not yet on PyPI. APIs and the underlying spec are
-preliminary and will change.
+Pre-alpha. Foundation shipped: document parsing (PDF/DOCX, clause detection),
+PII stripping (Presidio, 16 entity types, encrypted mapping), AI provider gateway
+(33 models, 8 providers, routing + cost tracking + health check), and SLM
+provider-specific pass-through params (`extra_params` in config.yml). The package
+is not yet on PyPI. APIs and the underlying spec are preliminary and will change.
 
 | Metric                      | Value                     |
 |-----------------------------|---------------------------|
-| Unit + integration tests    | 242                       |
+| Unit + integration tests    | 262                       |
 | CLI commands                | 19                        |
 | SQLite tables               | 7                         |
 | CI jobs                     | 4 (lint, types, test, memory) |
 | Memory budget (processing)  | < 100 MB (NLP model exempt) |
 | Startup (warm)              | < 0.3 s                   |
-| PII entity types detected   | 11 body + 4 metadata      |
+| PII entity types detected   | 16                        |
 | AI provider models          | 33 (across 8 providers)   |
 
 ### Parsing performance (real-world benchmark)
@@ -189,7 +190,17 @@ uv run openreview --version
 | `tests/unit/test_database.py`                       | 7 tests (init, cost, limits, clients)      |
 | `tests/unit/test_cli_config.py`                     | 8 tests (show, get, set, validation)       |
 | `tests/unit/test_cli_client.py`                     | 5 tests (add, list, delete, --force)       |
-| `tests/unit/test_pii_*.py`                          | 40 tests (models, recognizers, placeholders, mapping, audit, engine) |
+| `tests/unit/test_pdf_parser.py`                     | 11 tests (PDF parsing, headings, metadata) |
+| `tests/unit/test_docx_parser.py`                    | 7 tests (DOCX parsing, tracked changes)    |
+| `tests/unit/test_clause_detector.py`                | 18 tests (clause detection, hierarchy)     |
+| `tests/unit/test_models.py`                         | 20 tests (Clause, Document, ParseError)    |
+| `tests/unit/test_pii_*.py`                          | 38 tests (models, recognizers, placeholders, mapping, audit, engine) |
+| `tests/unit/test_gateway_models.py`                 | 10 tests (ModelEntry, ProviderInfo)        |
+| `tests/unit/test_gateway_router.py`                 | 25 tests (chat, embed, rerank, extra_params, health check) |
+| `tests/unit/test_gateway_registry.py`               | 8 tests (registry load, Ollama discovery)  |
+| `tests/unit/test_gateway_cost.py`                   | 5 tests (per-token pricing)                |
+| `tests/unit/test_gateway_redaction.py`              | 8 tests (key redaction, RedactingFilter)   |
+| `tests/unit/test_gateway_wizard.py`                 | 2 tests (interactive setup)                |
 | `tests/conftest.py`                                 | Memory tracker fixture (< 110 MB)          |
 | `.pre-commit-config.yaml`                           | 10 hooks (ruff, mypy, pytest, hygiene)     |
 | `.github/workflows/ci.yml`                          | 4 parallel CI jobs                         |
@@ -219,6 +230,7 @@ openreview precheck --force-reprocess contract.pdf    # Bypass cache
 # PII management
 openreview pii list              # Documents with PII data
 openreview pii delete abc123     # Delete PII data for a document
+openreview pii cleanup           # Delete expired PII data
 
 # AI Gateway
 openreview gateway providers            # List supported providers
@@ -248,6 +260,7 @@ openreview gateway refresh              # Refresh model registry
 | `openreview precheck --no-pii <path>`  | NDA review, skip PII (raw text in output)  |
 | `openreview pii list`                  | List documents with stored PII data        |
 | `openreview pii delete <hash>`         | Delete all PII data for a document (GDPR)  |
+| `openreview pii cleanup`              | Delete documents with expired PII retention |
 | `openreview gateway providers`         | List all supported providers               |
 | `openreview gateway models <provider>` | List available models for a provider       |
 | `openreview gateway setup`             | Interactive provider/model configuration   |
@@ -266,7 +279,7 @@ Secrets (API keys) live in `auth.json` at the same path.
 | Section              | What it controls              | Example keys                       |
 |----------------------|-------------------------------|------------------------------------|
 | `privacy`            | PII stripping, log retention  | `tier`, `strip_pii`, `log_ttl_days`|
-| `gateway.models`     | LLM provider/model per task   | `reasoning.primary`, `extraction.params.temperature` |
+| `gateway.models`     | LLM provider/model per task   | `reasoning.primary`, `extraction.params.temperature`, `reasoning.extra_params` |
 | `gateway.fallback`   | Retry and timeout behavior    | `retries`, `timeout`, `on_failure` |
 | `gateway.cost_limits`| Spending caps                 | `per_review_cents`, `daily_cents`  |
 | `storage`            | Data retention                | `reviews_keep_forever`, `logs_keep_days` |

--- a/specs/006-slm-model-params/checklists/requirements.md
+++ b/specs/006-slm-model-params/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: SLM Model Params Extension
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-01
+**Feature**: [spec.md](file:///home/mohamed/lab/openreview/specs/006-slm-model-params/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec intentionally references `config.yml` and `health check` as product concepts, not implementation details. These are user-facing surfaces the user interacts with directly.
+- SC-005 references `mypy --strict` which is a development workflow tool, not an implementation detail — it validates the change doesn't break the existing type safety contract.
+- The spec notes that existing router code already partially implements `extra_params` (lines 98-100 of router.py). This spec formalises, hardens, and extends that existing behaviour rather than inventing new surface area.

--- a/specs/006-slm-model-params/contracts/cli-contract.md
+++ b/specs/006-slm-model-params/contracts/cli-contract.md
@@ -1,0 +1,93 @@
+# CLI Contract: SLM Model Params Extension
+
+**Date**: 2026-07-01 | **Feature**: 006-slm-model-params
+
+## Configuration Contract (config.yml)
+
+### Input: extra_params field on any model slot
+
+```yaml
+# Example: Ollama SLM with provider-specific params
+gateway:
+  models:
+    extraction:
+      primary: ollama/qwen3:8b
+      params:
+        temperature: 0.1
+        max_tokens: 4096
+      extra_params:         # NEW — provider-specific pass-through
+        num_gpu: 0          # CPU-only inference
+        num_ctx: 4096       # Reduced context window to save RAM
+        options:            # Nested structure supported
+          mirostat: 2
+```
+
+### Behaviour
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `extra_params` present and valid dict | Merged into LiteLLM call kwargs after `params` |
+| `extra_params` absent or `null` | No extra keys added — existing behaviour unchanged |
+| `extra_params` is empty dict `{}` | No extra keys added |
+| `extra_params` is non-dict (string, list, etc.) | Ignored silently, DEBUG log emitted |
+| `extra_params` contains protected key (`model`, `messages`, `input`, `timeout`) | Key stripped before merge, WARNING log emitted |
+| `extra_params` contains key that duplicates `params` (e.g. `temperature`) | `extra_params` value wins (applied after `params`) |
+
+### Merge Order
+
+```
+1. model    ← from slot config (primary)
+2. params   ← temperature, max_tokens from slot config
+3. extra_params ← provider-specific, protected keys stripped
+4. **kwargs ← caller-provided at runtime (chat/embed method args)
+```
+
+## Health Check Contract
+
+### Current output per slot:
+
+```json
+{
+  "reasoning": {"status": "configured", "provider": "openai"},
+  "extraction": {"status": "configured", "provider": "ollama"}
+}
+```
+
+### New output per slot (when extra_params present):
+
+```json
+{
+  "reasoning": {"status": "configured", "provider": "openai"},
+  "extraction": {"status": "configured", "provider": "ollama", "extra_params": 3}
+}
+```
+
+The `extra_params` key only appears when the slot has extra params configured. The value is the count of keys (integer), not the keys themselves.
+
+## Python API Contract
+
+### ModelEntry (models.py)
+
+```python
+# Before
+class ModelEntry(BaseModel):
+    slots: list[str]
+    context: int | None = None
+    # ... existing fields
+
+# After
+class ModelEntry(BaseModel):
+    slots: list[str]
+    context: int | None = None
+    # ... existing fields
+    extra_params: dict[str, Any] | None = None  # NEW
+```
+
+### Gateway._get_litellm_kwargs (router.py)
+
+No signature change. Internal behaviour change:
+1. Read `extra_params` from slot config (already done)
+2. **NEW**: Strip protected keys from `extra_params`
+3. **NEW**: Log stripped keys at WARNING level
+4. Merge remaining `extra_params` into call kwargs (already done)
+5. **NEW**: Log applied keys at DEBUG level

--- a/specs/006-slm-model-params/data-model.md
+++ b/specs/006-slm-model-params/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: SLM Model Params Extension
+
+**Date**: 2026-07-01 | **Feature**: 006-slm-model-params
+
+## Entities
+
+### ModelEntry (Pydantic BaseModel)
+
+**Location**: `src/openreview_cli/gateway/models.py`
+
+**Current fields**:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| slots | `list[str]` | required | Model capability slots (reasoning, extraction, etc.) |
+| context | `int \| None` | `None` | Context window size |
+| dimensions | `int \| None` | `None` | Embedding dimensions |
+| ram | `str \| None` | `None` | RAM requirement string |
+| recommended | `bool` | `False` | Whether model is recommended |
+| status | `str \| None` | `None` | Model availability status |
+| note | `str \| None` | `None` | Human-readable note |
+
+**New field**:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| extra_params | `dict[str, Any] \| None` | `None` | Provider-specific default params for documentation. Informational only — not enforced at runtime. |
+
+**Validation rules**: None — the field is a pass-through dict. Any key-value structure is valid.
+
+### SlotConfig (config.yml dict — not a Pydantic model)
+
+**Location**: Read from `config.yml` by `Gateway._get_slot_config()` in `router.py`
+
+**Current structure** (YAML):
+```yaml
+gateway:
+  models:
+    <slot_name>:
+      primary: <model_id>
+      fallback: <model_id>  # optional
+      params:               # optional
+        temperature: <float>
+        max_tokens: <int>
+      extra_params:         # optional — ALREADY PARSED (line 98-100)
+        <key>: <value>
+```
+
+**No structural change needed** — `extra_params` is already read from config. The change is in how `_get_litellm_kwargs()` processes it (adding protected-key stripping and logging).
+
+### Protected Keys (constant)
+
+**Location**: `src/openreview_cli/gateway/router.py`
+
+**Definition**: `_PROTECTED_KEYS = frozenset({"model", "messages", "input", "timeout"})`
+
+**Purpose**: Keys that `extra_params` must never override. Stripped before merging into call kwargs.
+
+## Relationships
+
+```
+config.yml (SlotConfig)
+  ├── primary → model ID (used in LiteLLM call)
+  ├── params → standard LLM params (temperature, max_tokens)
+  └── extra_params → provider-specific params
+        ├── stripped of protected keys → warning logged
+        └── merged into LiteLLM call kwargs
+
+models.json (ModelEntry)
+  └── extra_params → documentation of available provider-specific params
+        └── informational only — not merged into calls
+```
+
+## State Transitions
+
+N/A — no stateful entities. `extra_params` is configuration, not state.

--- a/specs/006-slm-model-params/plan.md
+++ b/specs/006-slm-model-params/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: SLM Model Params Extension
+
+**Branch**: `006-slm-model-params` | **Date**: 2026-07-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/006-slm-model-params/spec.md`
+
+## Summary
+
+Extend the gateway's `ModelParams` handling to support provider-specific pass-through parameters for SLM optimization. The gateway already has a partial implementation (router.py lines 98-100 read `extra_params` from config). This plan formalises that behaviour by adding protected-key stripping, debug/warning logging, health check visibility, and a documentation field on `ModelEntry`. No new dependencies required.
+
+## Technical Context
+
+**Language/Version**: Python 3.12.3 (pinned in `.python-version`)
+
+**Primary Dependencies**: Pydantic 2.13.4 (models), LiteLLM 1.90.1 (routing), stdlib `logging` (debug/warning output)
+
+**Storage**: N/A — no schema changes; `extra_params` lives in config.yml (YAML), not SQLite
+
+**Testing**: pytest (unit tests in `tests/unit/test_gateway_models.py` and `tests/unit/test_gateway_router.py`)
+
+**Target Platform**: Local CLI, Linux/macOS/Windows, 8 GB RAM reference machine
+
+**Project Type**: CLI (Python package `openreview-cli`)
+
+**Performance Goals**: Zero additional latency — `extra_params` merge is dict.update(), O(n) where n is number of extra keys (typically 1-5)
+
+**Constraints**: <100 MB peak memory (unchanged — no new allocations beyond a small dict)
+
+**Scale/Scope**: 3 files modified, 1 file unchanged, ~60 lines of new code, ~80 lines of new tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| I. Privacy First | PASS | No new network calls. `extra_params` values stay in config.yml (local). Keys logged at DEBUG level, not values. |
+| II. Local-First, CLI-Only | PASS | No server, no daemon. Config-only change. |
+| III. Hardware-Bounded | PASS | Dict merge adds negligible memory. No new imports. |
+| IV. Dependency Minimalism | PASS | Zero new dependencies. Uses existing Pydantic, stdlib logging. |
+| V. Spec-Driven, YAGNI | PASS | Specified in spec.md. Addresses blueprint R-4 and C-5. Minimal change — no speculative abstractions. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-slm-model-params/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (CLI contract)
+│   └── cli-contract.md
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/openreview_cli/gateway/
+├── models.py            # MODIFY — add extra_params field to ModelEntry
+├── router.py            # MODIFY — add protected-key stripping, logging, health check extra_params
+├── models.json          # MODIFY — add extra_params examples for Ollama models
+└── (other files)        # UNCHANGED
+
+tests/unit/
+├── test_gateway_models.py  # MODIFY — add extra_params tests for ModelEntry
+└── test_gateway_router.py  # MODIFY — add protected-key, logging, health check tests
+```
+
+**Structure Decision**: Single project, src layout. All changes are within the existing `src/openreview_cli/gateway/` package and `tests/unit/` directory. No new modules, no new directories.
+
+## Complexity Tracking
+
+No violations. No complexity justification needed.

--- a/specs/006-slm-model-params/quickstart.md
+++ b/specs/006-slm-model-params/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: SLM Model Params Extension
+
+**Date**: 2026-07-01 | **Feature**: 006-slm-model-params
+
+## Prerequisites
+
+- Python 3.12, `uv sync` completed
+- Existing gateway tests passing: `uv run pytest tests/unit/test_gateway_models.py tests/unit/test_gateway_router.py -q`
+
+## Validation Scenarios
+
+### Scenario 1: ModelEntry accepts extra_params
+
+**Run**:
+```bash
+uv run pytest tests/unit/test_gateway_models.py -q -k "extra_params"
+```
+
+**Expected**: All `extra_params`-related ModelEntry tests pass — construction with and without the field, serialization of nested dicts.
+
+### Scenario 2: Protected keys are stripped
+
+**Run**:
+```bash
+uv run pytest tests/unit/test_gateway_router.py -q -k "protected"
+```
+
+**Expected**: Tests confirm that `model`, `messages`, `input`, and `timeout` are stripped from `extra_params` before merging. Warning is logged.
+
+### Scenario 3: Health check shows extra_params count
+
+**Run**:
+```bash
+uv run pytest tests/unit/test_gateway_router.py -q -k "health" 
+```
+
+**Expected**: Health check output includes `extra_params: N` for slots with extra params configured.
+
+### Scenario 4: Full regression
+
+**Run**:
+```bash
+uv run pytest tests/unit/test_gateway_models.py tests/unit/test_gateway_router.py -q
+```
+
+**Expected**: All existing and new tests pass. Zero regressions.
+
+### Scenario 5: Type safety
+
+**Run**:
+```bash
+uv run mypy src/openreview_cli/gateway/models.py src/openreview_cli/gateway/router.py --strict
+```
+
+**Expected**: No type errors. `extra_params: dict[str, Any] | None = None` is mypy-strict compatible.
+
+## Links
+
+- Data model: [data-model.md](data-model.md)
+- CLI contract: [contracts/cli-contract.md](contracts/cli-contract.md)
+- Research: [research.md](research.md)

--- a/specs/006-slm-model-params/research.md
+++ b/specs/006-slm-model-params/research.md
@@ -1,0 +1,53 @@
+# Research: SLM Model Params Extension
+
+**Date**: 2026-07-01 | **Feature**: 006-slm-model-params
+
+## Research Tasks
+
+### R1: LiteLLM Provider-Specific Parameter Forwarding
+
+**Decision**: LiteLLM forwards all non-OpenAI kwargs to the underlying provider as-is.
+
+**Rationale**: Confirmed via official LiteLLM docs (v1.90.1, installed). The `completion()` and `embedding()` functions accept `**kwargs` and route any unrecognised parameter directly to the provider SDK. This is explicitly documented for Sagemaker (`top_k`), Bedrock, Ollama, and others. The Ollama provider supports parameters like `num_gpu`, `num_ctx`, `num_thread`, and the `options` dict.
+
+**Alternatives considered**:
+- Wrapping each provider's params in an `extra_body` dict — rejected because LiteLLM handles this internally and top-level kwargs are the documented approach.
+- Validating extra_params against known provider schemas — rejected as over-engineering (YAGNI). The provider SDK will reject invalid params; we don't need to duplicate that validation.
+
+### R2: Protected Key Set
+
+**Decision**: Strip `{model, messages, input, timeout}` from `extra_params` before merging.
+
+**Rationale**: These four keys are structurally required by the gateway routing logic:
+- `model` — set by `_get_litellm_kwargs()` from the slot's `primary` config
+- `messages` — set by `chat()` from the caller's message list
+- `input` — set by `embed()` from the caller's text list
+- `timeout` — set by `_call_with_fallback()` from the fallback config
+
+Allowing `extra_params` to override these would break routing silently. The current code already sets `model` before merging `extra_params` (line 91), but `extra_params` would override it via `kwargs.update(extra)` (line 100). This is a bug in the current implementation that this feature fixes.
+
+**Alternatives considered**:
+- Raising an exception when protected keys appear — rejected because users may have stale config when switching providers. A warning log is more user-friendly.
+- Extending the protected set to include `temperature` and `max_tokens` — rejected because `extra_params` should be able to override standard params (spec edge case: `extra_params` overrides `params`).
+
+### R3: Merge Order
+
+**Decision**: `params` → `extra_params` → caller `**kwargs`
+
+**Rationale**: The current code applies `params` first (temperature, max_tokens), then `extra_params` via `kwargs.update(extra)`. The `chat()` method then adds caller kwargs via `call_kwargs.update(kwargs)`. This means the merge order is: slot config params → extra_params → runtime caller kwargs. This is correct: provider-specific config overrides generic config, and runtime args override everything.
+
+**Alternatives considered**: None — the current order is already correct.
+
+### R4: Health Check Extra Params Visibility
+
+**Decision**: Add `extra_params` count (integer) to health check output for slots that have extra params configured.
+
+**Rationale**: The health check currently returns `{status, provider}` per slot. Adding `extra_params: N` (where N is the count of keys) makes it visible that provider-specific config is active without exposing the actual values (which could contain sensitive provider config).
+
+**Alternatives considered**:
+- Listing the extra_params key names — rejected because it adds verbosity with minimal benefit. The count is sufficient for "is it active?" verification.
+- Exposing values — rejected per Privacy First (Principle I). Even though these are config values not PII, the principle of minimal disclosure applies.
+
+## No NEEDS CLARIFICATION Items
+
+All technical questions resolved from existing code and LiteLLM documentation. No unresolved unknowns.

--- a/specs/006-slm-model-params/spec.md
+++ b/specs/006-slm-model-params/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: SLM Model Params Extension
+
+**Feature Branch**: `006-slm-model-params`
+
+**Created**: 2026-07-01
+
+**Status**: Draft
+
+**Input**: User description: "N-3 Extend gateway ModelParams for SLM optimization"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pass Provider-Specific Parameters to Local SLMs (Priority: P1)
+
+A user configures an Ollama-hosted SLM (e.g. `qwen3:8b`) for the extraction slot. To maximise quality on their 16 GB machine, they set `num_gpu: 0` (CPU-only) and `num_ctx: 4096` (reduced context to save RAM). These parameters are specific to Ollama and do not exist on cloud providers. The gateway passes them through to LiteLLM without modification, and the model runs with the requested settings.
+
+**Why this priority**: Without provider-specific pass-through, SLMs run with LiteLLM defaults that may be suboptimal or even crash the machine (e.g. trying to allocate GPU memory on a machine with no GPU). This is the core value of N-3.
+
+**Independent Test**: Can be tested by configuring `extra_params` in `config.yml` for an Ollama model slot and verifying the parameters appear in the LiteLLM call kwargs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a config with `extra_params: {num_gpu: 0, num_ctx: 4096}` on the extraction slot, **When** the gateway routes a chat call to that slot, **Then** the LiteLLM call kwargs include `num_gpu=0` and `num_ctx=4096`.
+2. **Given** a config with no `extra_params`, **When** the gateway routes a chat call, **Then** only standard parameters (`temperature`, `max_tokens`) are included — no extra keys appear.
+3. **Given** a config with `extra_params` containing nested values (e.g. `options: {mirostat: 2}`), **When** the gateway routes a call, **Then** the nested structure passes through intact.
+
+---
+
+### User Story 2 - Cloud Providers Ignore Irrelevant Extra Params (Priority: P2)
+
+A user switches their extraction slot from Ollama (`qwen3:8b` with `num_gpu: 0`) to OpenAI (`gpt-4o`). They forget to remove the `extra_params`. The gateway still routes the call. LiteLLM either passes the unknown parameter (and the provider ignores it) or the gateway logs a warning. The call does not crash.
+
+**Why this priority**: Safety net. Users switch providers during experimentation. The gateway should not error on stale configuration.
+
+**Independent Test**: Can be tested by configuring `extra_params` with Ollama-specific keys on an OpenAI model and verifying the call completes (with a warning logged, not an exception).
+
+**Acceptance Scenarios**:
+
+1. **Given** an OpenAI model configured with `extra_params: {num_gpu: 0}`, **When** the gateway routes a call, **Then** the call kwargs include `num_gpu=0` (LiteLLM handles provider filtering) and no exception is raised.
+
+---
+
+### User Story 3 - View Active Extra Params in Health Check (Priority: P3)
+
+A user runs the gateway health check to see which models are configured. For slots that have `extra_params`, the health check output includes a count of extra parameters (e.g. `extra_params: 2 keys`) so the user knows pass-through config is active.
+
+**Why this priority**: Discoverability. Without visibility, users cannot confirm their extra params are actually being picked up.
+
+**Independent Test**: Can be tested by running a health check on a gateway with extra_params configured and verifying the output includes extra_params information.
+
+**Acceptance Scenarios**:
+
+1. **Given** a slot with `extra_params: {num_gpu: 0, num_ctx: 4096}`, **When** the user runs health check, **Then** the slot's health output includes `"extra_params": 2`.
+2. **Given** a slot with no `extra_params`, **When** the user runs health check, **Then** no `extra_params` key appears in that slot's output.
+
+---
+
+### Edge Cases
+
+- What happens when `extra_params` contains a key that conflicts with a standard parameter (e.g. `extra_params: {temperature: 0.5}` when `params.temperature` is already 0.7)? — `extra_params` overrides `params` because it is applied after standard params.
+- What happens when `extra_params` contains an empty dict (`{}`)? — Treated as no extra params; no keys are added.
+- What happens when `extra_params` is set to a non-dict value (e.g. a string or list)? — Rejected at config load time by Pydantic `ValidationError` (the `ModelSlot` model in `_validate_and_merge` defines `extra_params: dict[str, Any] | None`).
+- What happens when `extra_params` contains the key `model` or `messages`? — These are critical call keys. `extra_params` MUST NOT override `model` or `messages`. The gateway strips these keys before merging and logs a warning.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The gateway MUST support an `extra_params` field on each model slot in `config.yml` that accepts an arbitrary key-value mapping.
+- **FR-002**: The gateway MUST merge `extra_params` into the LiteLLM call kwargs after standard params (`temperature`, `max_tokens`), allowing `extra_params` to override standard params.
+- **FR-003**: The gateway MUST strip the keys `model`, `messages`, `input`, and `timeout` from `extra_params` before merging, to protect call-critical parameters.
+- **FR-004**: The gateway MUST log at DEBUG level when `extra_params` are applied, listing the keys (not values) being passed through.
+- **FR-005**: The gateway MUST log at WARNING level if `extra_params` contains a protected key that was stripped.
+- **FR-006**: The `ModelEntry` dataclass MUST include an optional `extra_params` field for the static model registry, allowing per-model default extra params to be documented.
+- **FR-007**: The gateway health check MUST report the count of active `extra_params` for each configured slot.
+- **FR-008**: The `extra_params` field MUST support nested dict values (pass-through intact) for providers that accept structured options (e.g. Ollama's `options` object).
+
+### Key Entities
+
+- **SlotConfig (config.yml)**: A model slot configuration with `primary`, `fallback`, `params`, and the new `extra_params` field. Lives in the user's `config.yml`.
+- **ModelEntry (models.json)**: A static registry entry documenting known models. The new `extra_params` field here is for documentation — showing users what provider-specific params a model supports.
+- **Protected Keys**: The set `{model, messages, input, timeout}` — keys that `extra_params` must never override because they are structurally required by the gateway routing logic.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Any key-value pair placed in `extra_params` in config.yml appears in the LiteLLM call kwargs, verifiable in unit tests.
+- **SC-002**: Protected keys (`model`, `messages`, `input`, `timeout`) are never overridden by `extra_params`, verifiable in unit tests.
+- **SC-003**: Health check output includes extra_params count for configured slots, verifiable in unit tests.
+- **SC-004**: All existing gateway tests continue to pass — zero regressions.
+- **SC-005**: `mypy --strict` passes with the new `extra_params` field on both `ModelEntry` and config handling.
+
+## Clarifications
+
+### Session 2026-07-01
+
+- Q: Should SlotConfig become a typed Pydantic model or remain dict-based? → A: Dict-based — keep current approach, add validation/logic in `_get_litellm_kwargs` only.
+
+## Assumptions
+
+- LiteLLM passes unknown kwargs through to the provider SDK without raising errors. This is documented LiteLLM behavior — it forwards `**kwargs` to the underlying provider.
+- The `extra_params` field in `config.yml` is already parsed by the gateway's `_get_litellm_kwargs` method (the router code at line 98-100 already reads `extra_params` from config and merges them). This spec formalises and hardens that behaviour.
+- No new dependencies are required. This is a pure Python change to existing Pydantic models and routing logic.
+- The `extra_params` field on `ModelEntry` (models.json) is informational — it documents what provider-specific params are available, but is not enforced at runtime.

--- a/specs/006-slm-model-params/tasks.md
+++ b/specs/006-slm-model-params/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: SLM Model Params Extension
+
+**Input**: Design documents from `/specs/006-slm-model-params/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cli-contract.md
+
+**Tests**: Included per project TDD mandate (AGENTS.md). All tests written FIRST, verified FAILING, then implementation.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline — no structural changes needed (all work is in existing files per plan.md)
+
+- [X] T001 Verify existing gateway tests pass: `uv run pytest tests/unit/test_gateway_models.py tests/unit/test_gateway_router.py -q`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core model changes that all user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 [P] Add `extra_params: dict[str, Any] | None = None` field to `ModelEntry` in `src/openreview_cli/gateway/models.py`
+- [X] T003 [P] Define `_PROTECTED_KEYS = frozenset({"model", "messages", "input", "timeout"})` in `src/openreview_cli/gateway/router.py`
+
+**Checkpoint**: Model foundation ready — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Pass Provider-Specific Params to Local SLMs (Priority: P1) 🎯 MVP
+
+**Goal**: Users configure `extra_params` (e.g. `num_gpu`, `num_ctx`) on Ollama model slots in `config.yml`. These params pass through to LiteLLM. Protected keys are stripped. Debug/warning logs emitted.
+
+**Independent Test**: `uv run pytest tests/unit/test_gateway_router.py -q -k "extra_params"` — all extra_params-related tests pass.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T004 [P] [US1] Add ModelEntry extra_params tests (construction with/without field, serialization of nested dicts, `None` default) in `tests/unit/test_gateway_models.py`
+- [X] T005 [P] [US1] Add extra_params pass-through tests (keys appear in LiteLLM kwargs, missing key → no extra keys, empty dict → no extra keys, nested values pass through, extra_params overrides standard params) in `tests/unit/test_gateway_router.py`
+- [X] T006 [P] [US1] Add protected key stripping tests (model/messages/input/timeout stripped before merge, non-dict silently ignored) in `tests/unit/test_gateway_router.py`
+- [X] T007 [P] [US1] Add extra_params logging tests (DEBUG message when extra_params applied listing keys, WARNING message when protected keys stripped) in `tests/unit/test_gateway_router.py`
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement protected-key stripping in `_get_litellm_kwargs()` — add filtering dict comprehension before `kwargs.update(extra)` in `src/openreview_cli/gateway/router.py`
+- [X] T009 [US1] Add DEBUG-level logging for applied extra_params keys and WARNING-level logging for stripped protected keys in `src/openreview_cli/gateway/router.py`
+
+**Checkpoint**: US1 functional — extra_params pass-through works, protected keys stripped, logs emitted. MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Cloud Providers Ignore Irrelevant Extra Params (Priority: P2)
+
+**Goal**: Stale extra_params from a previous provider (e.g. `num_gpu` on an OpenAI slot) do not crash the call.
+
+**Independent Test**: Configuring Ollama-specific `extra_params` on an OpenAI model slot and verifying the call completes without exception.
+
+### Tests for User Story 2 ⚠️
+
+- [X] T010 [US2] Add cross-provider extra_params safety test (Ollama-specific keys on OpenAI slot → call completes, no exception raised) in `tests/unit/test_gateway_router.py`
+
+**Checkpoint**: US2 confirmed — grace period covers stale config during provider switching. No new implementation code needed (US1 implementation handles this — LiteLLM forwards unknown kwargs).
+
+---
+
+## Phase 5: User Story 3 — View Active Extra Params in Health Check (Priority: P3)
+
+**Goal**: `health_check()` output includes `"extra_params": N` for slots with extra_params configured.
+
+**Independent Test**: `uv run pytest tests/unit/test_gateway_router.py -q -k "health"` — health check tests pass including extra_params count.
+
+### Tests for User Story 3 ⚠️
+
+- [X] T011 [US3] Add health check extra_params tests (slot with extra_params → output includes count, slot without → no extra_params key, verifiable in unit test) in `tests/unit/test_gateway_router.py`
+
+### Implementation for User Story 3
+
+- [X] T012 [US3] Add extra_params count to `health_check()` output in `src/openreview_cli/gateway/router.py` — after determining slot status, add `"extra_params": N` if slot config has extra_params dict
+
+**Checkpoint**: US3 functional — health check reports extra_params count per slot.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, docs, and regression check
+
+- [X] T013 [P] Add extra_params examples for Ollama models in `src/openreview_cli/gateway/models.json` (at least 2 Ollama entries demonstrating num_gpu, num_ctx, options)
+- [X] T014 Run full regression: `uv run pytest tests/unit/test_gateway_models.py tests/unit/test_gateway_router.py -q`
+- [X] T015 Run mypy strict check: `uv run mypy src/openreview_cli/gateway/models.py src/openreview_cli/gateway/router.py --strict`
+- [X] T016 Run quickstart validation scenarios per `specs/006-slm-model-params/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — verify baseline first
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2 — MVP, must complete first
+- **User Story 2 (Phase 4)**: Depends on Phase 3 (reuses same implementation)
+- **User Story 3 (Phase 5)**: Depends on Phase 2 (independent of US1/US2 implementation)
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependencies on other stories — can start after Phase 2
+- **US2 (P2)**: Depends on US1 implementation (same `_get_litellm_kwargs()` code handles both). No additional implementation code needed.
+- **US3 (P3)**: Independent — can start after Phase 2, parallel with US1 if desired
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (TDD per AGENTS.md)
+- Tests before implementation within each phase
+- T008 depends on T005, T006, T007 (tests first)
+- T009 depends on T007 (logging test)
+- T012 depends on T011
+
+### Parallel Opportunities
+
+- **Phase 2**: T002 (models.py) and T003 (router.py) — different files, parallel
+- **Phase 3 tests**: T004, T005, T006, T007 — all different test areas, fully parallel
+- **Phase 6**: T013, T014, T015, T016 — independent concerns, parallel
+
+---
+
+## Phase 7: Convergence
+
+**Purpose**: Align spec edge-case description with actual behavior
+
+- [X] T017 Update spec.md Edge Cases entry for non-dict `extra_params` — replace "Ignored silently; a debug-level log message is emitted" with "Rejected at config load time by Pydantic `ValidationError` (defined as `dict[str, Any] | None` on `ModelSlot`)" per spec.md Edge Cases (`contradicts`)
+
+---
+
+## Parallel Example: Phase 3 (US1) Tests
+
+```bash
+# Launch all US1 tests in parallel:
+Task: "Add ModelEntry extra_params tests in tests/unit/test_gateway_models.py"
+Task: "Add extra_params pass-through tests in tests/unit/test_gateway_router.py"
+Task: "Add protected key stripping tests in tests/unit/test_gateway_router.py"
+Task: "Add extra_params logging tests in tests/unit/test_gateway_router.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1: T001 — verify baseline passing
+2. Phase 2: T002 + T003 — ModelEntry field + protected keys constant
+3. Phase 3: T004–T007 (tests) → T008–T009 (implementation)
+4. **STOP and VALIDATE**: US1 independently testable, all tests green
+5. MVP ready — extra_params pass-through with protected key stripping
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. US1 → Test independently → MVP (extra_params pass-through, protected key stripping, logging)
+3. US2 → Test independently → Safety net confirmed
+4. US3 → Test independently → Health check visibility
+5. Polish → Regression, types, quickstart validation → Feature complete

--- a/src/openreview_cli/gateway/models.json
+++ b/src/openreview_cli/gateway/models.json
@@ -75,7 +75,12 @@
           "ram": "5.2 GB",
           "recommended": true,
           "status": "active",
-          "note": "Local — requires ~5.2 GB RAM"
+          "note": "Local — requires ~5.2 GB RAM",
+          "extra_params": {
+            "num_ctx": 32768,
+            "num_gpu": 1,
+            "num_predict": 4096
+          }
         },
         "qwen3:4b": {
           "slots": ["reasoning", "extraction", "graph"],
@@ -83,7 +88,15 @@
           "ram": "2.8 GB",
           "recommended": false,
           "status": "active",
-          "note": "Local — faster, less capable"
+          "note": "Local — faster, less capable",
+          "extra_params": {
+            "num_ctx": 16384,
+            "num_gpu": 0,
+            "num_predict": 2048,
+            "options": {
+              "mirostat": 2
+            }
+          }
         },
         "nomic-embed-text": {
           "slots": ["embedding"],

--- a/src/openreview_cli/gateway/models.py
+++ b/src/openreview_cli/gateway/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel
 
 
@@ -18,6 +20,7 @@ class ModelEntry(BaseModel):
     recommended: bool = False
     status: str | None = None
     note: str | None = None
+    extra_params: dict[str, Any] | None = None
 
 
 class CostRecord(BaseModel):

--- a/src/openreview_cli/gateway/router.py
+++ b/src/openreview_cli/gateway/router.py
@@ -24,6 +24,7 @@ from openreview_cli.storage.database import check_daily_limit, check_session_lim
 
 logger = logging.getLogger(__name__)
 
+_PROTECTED_KEYS = frozenset({"model", "messages", "input", "timeout"})
 VALID_SLOTS = frozenset({"reasoning", "extraction", "embedding", "reranking", "graph"})
 _PRIMARY_ONLY_SLOTS = frozenset({"embedding", "reranking"})
 _SLOT_METHOD_MAP: dict[str, str] = {
@@ -97,7 +98,15 @@ class Gateway:
                 kwargs["max_tokens"] = params["max_tokens"]
         extra = cfg.get("extra_params")
         if extra and isinstance(extra, dict):
-            kwargs.update(extra)
+            stripped = {k: v for k, v in extra.items() if k not in _PROTECTED_KEYS}
+            protected_stripped = extra.keys() - stripped.keys()
+            if protected_stripped:
+                logger.warning(
+                    "Stripped protected key(s) from extra_params: %s", protected_stripped
+                )
+            if stripped:
+                logger.debug("Applying extra_params: %s", list(stripped.keys()))
+            kwargs.update(stripped)
         return kwargs
 
     def _check_cost_limits(self, session_id: str | None) -> None:
@@ -282,4 +291,7 @@ class Gateway:
                 result[slot_name] = {"status": "missing_api_key", "provider": provider}
             else:
                 result[slot_name] = {"status": "configured", "provider": provider}
+            extra = cfg.get("extra_params")
+            if isinstance(extra, dict) and extra:
+                result[slot_name]["extra_params"] = len(extra)
         return result

--- a/tests/unit/test_gateway_models.py
+++ b/tests/unit/test_gateway_models.py
@@ -10,6 +10,7 @@ class TestModelEntry:
         assert m.recommended is False
         assert m.status is None
         assert m.note is None
+        assert m.extra_params is None
 
     def test_creates_with_all_fields(self) -> None:
         m = ModelEntry(
@@ -23,6 +24,27 @@ class TestModelEntry:
         )
         assert m.context == 4096
         assert m.recommended is True
+
+    def test_extra_params_default_none(self) -> None:
+        m = ModelEntry(slots=["reasoning"])
+        assert m.extra_params is None
+
+    def test_extra_params_with_dict(self) -> None:
+        m = ModelEntry(slots=["reasoning"], extra_params={"num_ctx": 4096, "num_gpu": 0})
+        assert m.extra_params == {"num_ctx": 4096, "num_gpu": 0}
+
+    def test_extra_params_with_nested_dict(self) -> None:
+        m = ModelEntry(
+            slots=["reasoning"],
+            extra_params={"options": {"mirostat": 2, "num_ctx": 8192}},
+        )
+        assert m.extra_params is not None
+        assert m.extra_params["options"]["mirostat"] == 2
+
+    def test_extra_params_serializes(self) -> None:
+        m = ModelEntry(slots=["reasoning"], extra_params={"top_k": 40, "top_p": 0.9})
+        d = m.model_dump()
+        assert d["extra_params"] == {"top_k": 40, "top_p": 0.9}
 
 
 class TestProviderInfo:

--- a/tests/unit/test_gateway_router.py
+++ b/tests/unit/test_gateway_router.py
@@ -184,6 +184,147 @@ class TestRerank:
         ]
 
 
+class TestGetLitellmKwargs:
+    def test_returns_correct_kwargs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs["model"] == "openai/gpt-4"
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["max_tokens"] == 2048
+        assert kwargs["top_p"] == 0.9
+
+
+class TestExtraParamsPassThrough:
+    def test_keys_appear_in_kwargs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs.get("top_p") == 0.9
+
+    def test_no_extra_params_yields_no_extra_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG)
+        kwargs = gw._get_litellm_kwargs("extraction")
+        assert "top_p" not in kwargs
+
+    def test_empty_dict_adds_no_keys(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n", "      extra_params: {}\n"
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert "top_p" not in kwargs
+
+    def test_nested_values_pass_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        options:\n          mirostat: 2\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs.get("options") == {"mirostat": 2}
+
+    def test_extra_params_overrides_standard_params(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        temperature: 0.1\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs["temperature"] == 0.1
+
+
+class TestExtraParamsProtectedKeys:
+    def test_model_key_stripped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        model: gpt-5\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs["model"] == "openai/gpt-4"
+
+    def test_messages_key_stripped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        messages: [bad]\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert "messages" not in kwargs
+        assert kwargs["model"] == "openai/gpt-4"
+
+    def test_input_key_stripped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        input: bad\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert "input" not in kwargs
+
+    def test_timeout_key_stripped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        timeout: 999\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs.get("timeout", None) != 999
+
+    def test_non_dict_rejected_by_config_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_core import ValidationError as PydanticValidationError
+
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params: not_a_dict\n",
+        )
+        with pytest.raises(PydanticValidationError):
+            _gateway(tmp_path, monkeypatch, config)
+
+
+class TestExtraParamsLogging:
+    def test_debug_logged_when_extra_params_applied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("DEBUG")
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG)
+        gw._get_litellm_kwargs("reasoning")
+        assert any("extra_params" in msg and "top_p" in msg for msg in caplog.messages)
+
+    def test_warning_logged_when_protected_key_stripped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING")
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        model: gpt-5\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        gw._get_litellm_kwargs("reasoning")
+        assert any("Stripped protected key" in msg and "model" in msg for msg in caplog.messages)
+
+
+class TestExtraParamsCrossProvider:
+    def test_ollama_params_on_openai_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        num_gpu: 0\n        num_ctx: 4096\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config)
+        kwargs = gw._get_litellm_kwargs("reasoning")
+        assert kwargs.get("num_gpu") == 0
+        assert kwargs.get("num_ctx") == 4096
+
+
 class TestHealthCheck:
     def test_returns_status_per_slot(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         config = """\
@@ -199,12 +340,27 @@ gateway:
             assert "status" in result[slot]
         assert result["reasoning"]["status"] == "missing_api_key"
 
+    def test_includes_extra_params_count_when_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG, "{}")
+        result = gw.health_check()
+        assert result["reasoning"].get("extra_params") == 1
 
-class TestGetLitellmKwargs:
-    def test_returns_correct_kwargs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG)
-        kwargs = gw._get_litellm_kwargs("reasoning")
-        assert kwargs["model"] == "openai/gpt-4"
-        assert kwargs["temperature"] == 0.7
-        assert kwargs["max_tokens"] == 2048
-        assert kwargs["top_p"] == 0.9
+    def test_no_extra_params_key_when_not_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gw = _gateway(tmp_path, monkeypatch, COMMON_CONFIG, "{}")
+        result = gw.health_check()
+        assert "extra_params" not in result["extraction"]
+
+    def test_extra_params_count_with_multiple_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = COMMON_CONFIG.replace(
+            "      extra_params:\n        top_p: 0.9\n",
+            "      extra_params:\n        num_gpu: 0\n        num_ctx: 4096\n        options:\n          mirostat: 2\n",
+        )
+        gw = _gateway(tmp_path, monkeypatch, config, "{}")
+        result = gw.health_check()
+        assert result["reasoning"].get("extra_params") == 3


### PR DESCRIPTION
Implements spec 006-slm-model-params: extra_params field on ModelEntry and slot config, protected-key stripping (model/messages/input/timeout), DEBUG/WARNING logging, health check extra_params count, and Ollama examples in models.json.

- src/openreview_cli/gateway/models.py: extra_params field on ModelEntry
- src/openreview_cli/gateway/router.py: _PROTECTED_KEYS, stripping, logging, health check
- src/openreview_cli/gateway/models.json: extra_params examples for qwen3:8b and qwen3:4b
- tests/: 20 new tests (35 total) across test_gateway_models.py and test_gateway_router.py
- README.md: update test count (242→262), status text, config docs, add pii cleanup
- specs/006-slm-model-params/: new feature artifacts (spec, plan, tasks, research, data-model, contracts, quickstart)
- .specify/: update feature pointer and memory files