### PR TITLE
feat: three-color output with confidence scores

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/012-citation-grounding"
+  "feature_directory": "specs/013-three-color-confidence"
 }

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ pass-through params (`extra_params` in config.yml), prompt management
 (versioned SQLite-backed storage, model-to-prompt binding, variable substitution,
 YAML export/import, A/B testing and GRPO optimization hooks defined), **and
 single-party contract review (PAKTON 3-agent pipeline: extraction, QA
-verification, report formatting), and citation grounding discriminator
-(post-hoc claim verification with strict/lenient modes, CG metrics, JSONL audit trail).**
+verification, report formatting), citation grounding discriminator
+(post-hoc claim verification with strict/lenient modes, CG metrics, JSONL audit trail),
+and three-color output with confidence scores (Green/Amber/Red with `--confidence-threshold` flag).**
 The package is not yet on PyPI. APIs and the underlying spec are preliminary and
 will change.
 
@@ -305,6 +306,8 @@ openreview precheck review --no-pii contract.pdf       # Skip PII stripping
 openreview precheck review --grounding-mode strict contract.pdf  # Strict grounding (excludes ungrounded claims)
 openreview precheck review --grounding-mode lenient contract.pdf # Lenient grounding (flags ungrounded)
 openreview precheck review --no-grounding contract.pdf  # Skip citation grounding entirely
+openreview precheck review --confidence-threshold 0.9 contract.pdf  # Raise threshold (more Amber flags)
+openreview precheck review --confidence-threshold 0.3 contract.pdf  # Lower threshold (fewer Amber flags)
 openreview precheck review --verbose contract.pdf      # Show per-clause progress
 openreview precheck review doc1.pdf doc2.pdf doc3.pdf  # Batch review
 
@@ -375,6 +378,7 @@ openreview benchmark --prompt-variant v1 --prompt-variant v2  # A/B prompt test
 | `openreview precheck review --grounding-mode lenient <paths>` | Lenient grounding (flag ungrounded claims, keep in output) |
 | `openreview precheck review --no-grounding <paths>` | Skip citation grounding entirely |
 | `openreview precheck review --verbose <paths>` | Show per-clause progress on stderr      |
+| `openreview precheck review --confidence-threshold <0.0-1.0> <paths>` | Threshold for Green/Amber/Red assignment (default 0.7) |
 | `openreview pii list`                  | List documents with stored PII data        |
 | `openreview pii delete <hash>`         | Delete all PII data for a document (GDPR)  |
 | `openreview pii cleanup`              | Delete documents with expired PII retention |

--- a/specs/013-three-color-confidence/checklists/requirements.md
+++ b/specs/013-three-color-confidence/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Three-Color Output with Confidence Scores
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — **0 remaining — resolved via `/speckit.clarify`**
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **0 [NEEDS CLARIFICATION] markers remaining** — all resolved via `/speckit.clarify`.
+- All four content quality items pass.
+- All requirement completeness items pass.
+- All feature readiness items pass.
+- The spec is ready for planning.

--- a/specs/013-three-color-confidence/contracts/cli-interface.md
+++ b/specs/013-three-color-confidence/contracts/cli-interface.md
@@ -1,0 +1,170 @@
+# CLI Interface Contract: Three-Color Output with Confidence Scores
+
+**Spec**: 013 — Three-Color Output with Confidence Scores
+**Date**: 2026-07-03
+
+---
+
+## `--confidence-threshold` Flag
+
+### Specification
+
+| Property | Value |
+|----------|-------|
+| **Name** | `--confidence-threshold` |
+| **Type** | `float` |
+| **Range** | `[0.0, 1.0]` |
+| **Default** | `0.7` |
+| **Scope** | Per-command (each review-producing subcommand) |
+| **Required** | No |
+| **Repeatable** | No |
+| **Environment variable** | None (CLI-only) |
+
+### Validation
+
+- Values `< 0.0` or `> 1.0` are rejected with:
+  ```
+  Error: Invalid value for '--confidence-threshold': <value> is not in the range [0.0, 1.0].
+  ```
+- Non-float values are rejected by Typer's built-in type coercion.
+
+### Help Text
+
+```
+--confidence-threshold FLOAT  [default: 0.7]
+  Confidence threshold for Green/Amber/Red assignment (0.0-1.0).
+  Clauses with effective confidence below this threshold are marked Amber.
+  Note: The comparison accuracy of automated review is bounded by
+  approximately 64% F1. Three-color output (Green/Amber/Red) is
+  designed to mitigate this — set the threshold generously to push
+  uncertain comparisons to Amber rather than risking false Green or Red.
+```
+
+---
+
+## CLI Invocation Examples
+
+### Default threshold
+```bash
+openreview precheck review document.pdf --playbook precheck-nda-v1
+```
+→ Uses threshold 0.7. Clauses with effective confidence >= 0.7 and favorable/neutral → Green. Unfavorable with confidence >= 0.7 → Red. Everything else → Amber.
+
+### Custom threshold (risk-averse)
+```bash
+openreview precheck review document.pdf --playbook precheck-nda-v1 --confidence-threshold 0.9
+```
+→ Only clauses with confidence >= 0.9 can be Green/Red. Most assessments will be Amber.
+
+### Custom threshold (relaxed)
+```bash
+openreview precheck review document.pdf --playbook precheck-nda-v1 --confidence-threshold 0.3
+```
+→ Only clauses with confidence < 0.3 trigger Amber from low confidence. QA disagreement, error, and grounding failure still trigger Amber.
+
+### Edge threshold (all pass)
+```bash
+openreview precheck review document.pdf --playbook precheck-nda-v1 --confidence-threshold 0.0
+```
+→ No clause is Amber due to confidence threshold. Only error/QA-disagree/grounding Amber triggers apply.
+
+### Edge threshold (all Amber)
+```bash
+openreview precheck review document.pdf --playbook precheck-nda-v1 --confidence-threshold 1.0
+```
+→ Every clause with confidence < 1.0 is Amber. Only perfect assessments (confidence=1.0, no triggers) pass.
+
+---
+
+## Terminal Output Format
+
+### Status Column (three-color badges)
+
+| Color | Badge | Meaning |
+|-------|-------|---------|
+| Green | `● OK` (green text) | Safe — no action needed |
+| Amber | `⚠ AMBER` (bold yellow) | Needs human review — reasons shown |
+| Red | `● RED` (bold red) | Problematic — needs attention |
+
+The Status column replaces the current binary `⚠ AMBER` / `OK` with the three-state display.
+
+### Amber Reason Breakdown
+
+When a clause is Amber, the reasons are visible in the detail. The terminal shows:
+- The `⚠ AMBER` badge in the Status column
+- Below the table, or in an expandable row, the specific reasons (e.g., "Low confidence (0.45), QA disagreement")
+
+### Summary Section
+
+```text
+Summary
+  Green:       5  (new)
+  Amber:       3  (existing, renamed from "Amber flags")
+  Red:         2  (new)
+  Favorable:   3
+  Neutral:     2
+  Unfavorable: 2
+  Uncertain:   1
+  No-match:    1
+
+  Amber flags: 3         (preserved for backward compat)
+  Avg confidence: 0.62
+  Avg effective confidence: 0.58   (new)
+  Confidence threshold: 0.7        (new)
+```
+
+---
+
+## JSON Output Schema
+
+### Assessment object additions
+
+```json
+{
+  "clause_id": "1",
+  "color": "amber",
+  "amber_reasons": ["low_confidence", "qa_disagreement"],
+  "effective_confidence": 0.45,
+  "is_amber": true,
+  "...existing fields...": {}
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `color` | `string` | One of `"green"`, `"amber"`, `"red"` |
+| `amber_reasons` | `array[string]` | List of reason strings (empty for Green/Red) |
+| `effective_confidence` | `number` | Aggregated confidence (null if not computed) |
+| `is_amber` | `boolean` | **DEPRECATED** — derived from `color` for backward compat |
+| `confidence_threshold` | `number` | At report root — the threshold used |
+
+### Summary additions
+
+```json
+{
+  "green_count": 5,
+  "red_count": 2,
+  "amber_count": 3,
+  "avg_confidence": 0.62,
+  "avg_effective_confidence": 0.58
+}
+```
+
+### Report root additions
+
+```json
+{
+  "confidence_threshold": 0.7,
+  "schema_version": "1.1.0"
+}
+```
+
+---
+
+## Backward Compatibility Guarantees
+
+1. **`is_amber` field**: Still present in JSON output, derived from `color`. Existing consumers reading `is_amber` continue to work.
+2. **`amber_count`**: Still present in summary.
+3. **`--confidence-threshold` is optional**: Omitting it uses the default — no behavioral change for existing scripts.
+4. **CLI exit codes**: Unchanged — all new error cases (invalid threshold) exit with the standard error code.
+5. **Existing review output format**: The terminal table structure is preserved; only the Status column content changes from binary to three-color.

--- a/specs/013-three-color-confidence/data-model.md
+++ b/specs/013-three-color-confidence/data-model.md
@@ -1,0 +1,170 @@
+# Data Model: Three-Color Output with Confidence Scores
+
+**Spec**: 013 — Three-Color Output with Confidence Scores
+**Date**: 2026-07-03
+
+---
+
+## New Entities
+
+### `AssessmentColor(StrEnum)`
+
+```python
+class AssessmentColor(StrEnum):
+    """First-class three-color status for a clause assessment."""
+    green = "green"
+    amber = "amber"
+    red = "red"
+```
+
+Replaces boolean `is_amber` as the primary color signal. Represents the final color-assigned verdict for one clause assessment. Derived deterministically from position, confidence, QA verdict, grounding verdict, error state, and user-configured threshold.
+
+### `AmberReason(StrEnum)`
+
+```python
+class AmberReason(StrEnum):
+    """Specific reason why an assessment is marked Amber."""
+    low_confidence = "low_confidence"
+    qa_disagreement = "qa_disagreement"
+    qa_uncertain = "qa_uncertain"
+    error = "error"
+    grounding_failure = "grounding_failure"
+    grounding_uncertain = "grounding_uncertain"
+```
+
+Each reason corresponds to a specific Amber trigger defined in FR-004. Multiple reasons may be active for a single assessment (e.g., low confidence AND QA disagreement).
+
+---
+
+## Modified Entities
+
+### `ClauseAssessment` — additions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `color` | `AssessmentColor \| None` | `None` | Derived color status. Set at output time by `assign_colors()`. |
+| `amber_reasons` | `list[AmberReason] \| None` | `None` | Specific reasons this assessment is Amber. Empty list or None when color is Green or Red. |
+| `effective_confidence` | `float \| None` | `None` | Aggregated confidence score from extraction, QA, and grounding stages. Computed as `min(extraction, qa, grounding)` with missing stages defaulting to 1.0. |
+
+#### `is_amber` property (backward compat)
+
+```python
+@property
+def is_amber(self) -> bool:
+    """Backward-compat property — derives from color if set, otherwise falls back to stored bool."""
+    if self.color is not None:
+        return self.color == AssessmentColor.amber
+    return self._is_amber  # stored field from __post_init__ for pre-color consumers
+```
+
+The stored `is_amber` field in `__post_init__` is kept but renamed to `_is_amber` (private). The public `is_amber` becomes a property that:
+1. Returns `(color == amber)` if color is set (post-`assign_colors()`)
+2. Falls back to the stored `_is_amber` value for consumers that haven't called `assign_colors()` yet
+
+This ensures backward compatibility without breaking existing code that reads `ca.is_amber` before the color pipeline runs.
+
+### `ReviewSummary` — additions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `green_count` | `int` | `0` | Count of Green assessments |
+| `red_count` | `int` | `0` | Count of Red assessments |
+| `avg_effective_confidence` | `float` | `0.0` | Average of `effective_confidence` across all assessments (excluding assessments that errored) |
+
+`amber_count` is preserved unchanged for backward compatibility.
+
+### `ReviewReport` — additions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `confidence_threshold` | `float` | `0.7` | The threshold used for color assignment in this report |
+
+Records what threshold produced the output. Important for reproducibility — a report generated with `--confidence-threshold 0.7` will have different colors than one with `0.3`, and the report should record which was used.
+
+---
+
+## Color Assignment Rules
+
+The color assignment is a pure function `assign_colors(assessments, threshold)`:
+
+```
+Given threshold T and assessment A:
+
+# Compute effective confidence
+effective_confidence = min(
+    A.confidence or 1.0,
+    A.qa_confidence or 1.0,     # Note: qa_confidence not yet a field — future spec
+    A.grounding_confidence or 1.0
+)
+
+# Determine Amber triggers
+triggers = []
+if A.error is not None:
+    triggers.append(AmberReason.error)
+if effective_confidence < T:
+    triggers.append(AmberReason.low_confidence)
+if A.qa_verdict == QAVerdict.disagree:
+    triggers.append(AmberReason.qa_disagreement)
+if A.qa_verdict == QAVerdict.uncertain:
+    triggers.append(AmberReason.qa_uncertain)
+if A.grounding_verdict == GroundingVerdict.UNGROUNDED:
+    triggers.append(AmberReason.grounding_failure)
+if A.grounding_verdict == GroundingVerdict.UNCERTAIN:
+    triggers.append(AmberReason.grounding_uncertain)
+
+# Assign color
+if triggers:
+    color = AssessmentColor.amber
+elif A.position == Position.unfavorable and effective_confidence >= T:
+    color = AssessmentColor.red
+elif A.position in (Position.favorable, Position.neutral) and effective_confidence >= T:
+    color = AssessmentColor.green
+else:
+    color = AssessmentColor.amber  # catch-all (uncertain position without other triggers)
+    if A.position == Position.uncertain and AmberReason.qa_uncertain not in triggers:
+        triggers.append(AmberReason.qa_uncertain)
+
+# Set fields
+A.color = color
+A.effective_confidence = effective_confidence
+A.amber_reasons = triggers
+```
+
+### Summary of rules (from FR-002)
+
+| Condition | Color | Amber Reasons |
+|-----------|-------|---------------|
+| Error present | Amber | `[error]` |
+| Confidence < threshold (and no error) | Amber | `[low_confidence]` |
+| QA = disagree (and no error or low conf) | Amber | `[qa_disagreement]` |
+| QA = uncertain (and no other trigger) | Amber | `[qa_uncertain]` |
+| Grounding = ungrounded | Amber | `[grounding_failure]` |
+| Grounding = uncertain | Amber | `[grounding_uncertain]` |
+| Position = unfavorable, confidence >= T | Red | `[]` |
+| Position = favorable/neutral, confidence >= T | Green | `[]` |
+| Position = uncertain (no other triggers) | Amber | `[qa_uncertain]` (if qa caused it) |
+| Multiple triggers simultaneously | Amber | All applicable reasons |
+| No grounding data (grounding_verdict is None) | N/A | Grounding not a trigger |
+
+---
+
+## State Transitions
+
+**None.** Color is derived at report-build time by a pure function. It is not stored, not mutated, and not persisted. The only "state" is the user-provided `--confidence-threshold` value, which is passed as a parameter to `assign_colors()`.
+
+---
+
+## Schema Version Impact
+
+`ReviewReport.schema_version` is bumped from `"1.0.0"` to `"1.1.0"` (minor — additive fields only, no breaking changes).
+
+---
+
+## Dependency References
+
+| Item | Reference | Status |
+|------|-----------|--------|
+| `enum.StrEnum` | Python 3.11+ stdlib | ✅ Confirmed (Python 3.12 project) |
+| `dataclasses` | Python 3.7+ stdlib | ✅ Confirmed (exists in `review/models.py`) |
+| `typer.Option` | `typer` v0.12+ | ✅ Confirmed (exists in `app.py`) |
+| `rich.table` | `rich` v13+ | ✅ Confirmed (exists in `report.py`) |

--- a/specs/013-three-color-confidence/plan.md
+++ b/specs/013-three-color-confidence/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: Three-Color Output with Confidence Scores
+
+**Branch**: `013-three-color-confidence` | **Date**: 2026-07-03 | **Spec**: [`spec.md`](./spec.md)
+
+**Input**: Feature specification from `specs/013-three-color-confidence/spec.md`
+
+## Summary
+
+Replace the current binary amber/ok output with a three-color (Green/Amber/Red) status system. Add a `--confidence-threshold` CLI flag (default 0.7) that controls the boundary between high-confidence (Green/Red) and low-confidence (Amber) assessments. Color is derived at output time as a stateless O(n) mapping from existing assessment fields — no pipeline re-run required.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+
+**Primary Dependencies**: None new. Uses existing `dataclasses`, `enum.StrEnum`, `rich`, `typer`, `json` — all already installed.
+
+**Storage**: N/A — color is derived at output time, not persisted.
+
+**Testing**: pytest — unit tests for color assignment logic, integration tests for CLI flag, terminal rendering, and JSON output.
+
+**Target Platform**: Linux/macOS/Windows (CLI tool)
+
+**Project Type**: CLI tool (single-party review product mode)
+
+**Performance Goals**: Stateless O(n) per clause — 1,000 clauses in <100 ms. No pipeline re-run on threshold change. No measurable memory allocation beyond existing assessment list.
+
+**Constraints**: <100 MB peak memory, zero new runtime dependencies, backward compatibility with existing `is_amber` consumers (e.g., `app.py` lines checking `amber_count > 0`).
+
+**Scale/Scope**: ~1,000 clauses max per review. Color logic is trivially parallelizable but the single-threaded O(n) scan is well within budget.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Justification |
+|-----------|---------|---------------|
+| **I. Privacy First** | Pass | No new PII exposure. Confidence scores are derived from already-processed assessment data. |
+| **II. Local-First, CLI-Only** | Pass | No server, no daemon, no long-running process. Just a CLI flag + output formatting. |
+| **III. Hardware-Bounded** | Pass | Color assignment is O(1) per clause, no new memory-heavy operations, no new imports at module level. |
+| **IV. Dependency Minimalism** | Pass | Zero new runtime dependencies. Uses existing `rich`, `typer`, `dataclasses`, `enum.StrEnum`. |
+| **V. Spec-Driven, YAGNI** | Pass | Building only what N-6/R-6/§6.4 require. No speculative abstractions — color enum replaces boolean directly, no factory, no plugin system. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-three-color-confidence/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output — four research questions
+├── data-model.md        # Phase 1 output — entity definitions and color rules
+├── quickstart.md        # Phase 1 output — validation scenarios
+├── contracts/           # Phase 1 output — CLI interface contract
+│   └── cli-interface.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/openreview_cli/review/
+├── models.py            # Add AssessmentColor enum, AmberReason enum
+│                        # Modify ClauseAssessment: add color, effective_confidence, amber_reasons
+│                        # Modify ReviewSummary: add green_count, red_count
+│                        # Modify ReviewReport: add confidence_threshold
+├── report.py            # Three-color terminal rendering + JSON output with color field
+├── colors.py            # NEW — color assignment logic (pure function, testable)
+├── __init__.py          # Export new types and assign_color function
+├── base.py              # ReviewCommand: wire confidence_threshold through pipeline
+
+src/openreview_cli/app.py  # Add --confidence-threshold flag to review subcommands
+
+tests/unit/review/
+├── test_colors.py       # NEW — unit tests for color assignment logic
+
+tests/integration/
+├── test_three_color_output.py  # NEW — CLI flag, terminal rendering, JSON schema
+```
+
+**Structure Decision**: Single-project layout (Option 1). No new package — `colors.py` is a single file in the existing `review/` package. Tests follow the existing `tests/unit/` and `tests/integration/` convention.
+
+## Implementation Phases
+
+### Phase 1 — Data Model (models.py)
+
+Files: `src/openreview_cli/review/models.py`
+
+1. Add `AssessmentColor(StrEnum)` — `green`, `amber`, `red`
+2. Add `AmberReason(StrEnum)` — `low_confidence`, `qa_disagreement`, `qa_uncertain`, `error`, `grounding_failure`, `grounding_uncertain`
+3. Modify `ClauseAssessment`:
+   - Add `color: AssessmentColor | None = None` (set at output time, not in `__post_init__`)
+   - Add `amber_reasons: list[AmberReason] | None = None`
+   - Add `effective_confidence: float | None = None`
+   - Add `is_amber` property: `return self.color == AssessmentColor.AMBER` (computed from color, not stored)
+   - Keep existing `is_amber` field as backward-compat but deprecate it — the field will still be set in `__post_init__` for consumers that read it before color is assigned; the property takes precedence after color is set
+4. Modify `ReviewSummary`:
+   - Add `green_count: int = 0`
+   - Add `red_count: int = 0`
+   - Add `avg_effective_confidence: float = 0.0`
+   - Preserve `amber_count` as stored field (backward compat)
+5. Modify `ReviewReport`:
+   - Add `confidence_threshold: float = 0.7`
+
+### Phase 2 — Color Assignment Logic (colors.py + models.py)
+
+Files: `src/openreview_cli/review/colors.py`, `src/openreview_cli/review/__init__.py`
+
+1. Create `colors.py` with pure function `assign_colors(assessments, threshold=0.7)`:
+   - Computes `effective_confidence = min(extraction_confidence, qa_confidence, grounding_confidence)` with missing stages defaulting to 1.0
+   - Applies the rule set from spec FR-002 and the data-model.md color rules
+   - Returns updated assessments with `color`, `effective_confidence`, `amber_reasons` set
+   - Pure function: no side effects, no I/O, deterministic
+2. Update `ReviewSummary` computation to include `green_count`, `red_count`, `avg_effective_confidence`
+3. Export `assign_colors`, `AssessmentColor`, `AmberReason` from `review/__init__.py`
+
+### Phase 3 — Terminal Rendering (report.py)
+
+Files: `src/openreview_cli/review/report.py`
+
+1. Replace binary `⚠ AMBER` / `OK` status with three-state color badge:
+   - Green → `[green]● OK[/green]`
+   - Amber → `[bold yellow]⚠ AMBER[/bold yellow]`
+   - Red → `[bold red]● RED[/bold red]`
+2. Add Amber reason detail in terminal output when `amber_reasons` is non-empty (e.g., an expandable detail row or secondary line)
+3. Add `green_count` and `red_count` to summary section
+4. Add `avg_effective_confidence` to summary section
+5. Call `assign_colors()` before rendering if colors are not already set
+
+### Phase 4 — JSON Output (report.py)
+
+Files: `src/openreview_cli/review/report.py`
+
+1. Add `"color"` field to each assessment in JSON output
+2. Add `"amber_reasons"` field (list of strings)
+3. Add `"effective_confidence"` field
+4. Add `"confidence_threshold"` field to report root
+5. Add `green_count`, `red_count`, `avg_effective_confidence` to summary
+6. Keep `is_amber` boolean in JSON for backward compat (derived from color)
+
+### Phase 5 — CLI Flag (app.py)
+
+Files: `src/openreview_cli/app.py`, `src/openreview_cli/review/base.py`
+
+1. Define `DEFAULT_CONFIDENCE_THRESHOLD = 0.7` shared constant
+2. Add `--confidence-threshold` flag to every review-producing subcommand:
+   - Type: `float`, range: `[0.0, 1.0]` with Typer callback validation
+   - Default: `0.7`
+   - Help text includes accuracy ceiling disclosure (FR-008)
+3. Wire `confidence_threshold` through `ReviewCommand` to the report rendering step
+4. Validate flag value: `0.0 <= value <= 1.0`, reject with clear error otherwise
+
+### Phase 6 — Tests
+
+Files: `tests/unit/review/test_colors.py`, `tests/integration/test_three_color_output.py`
+
+1. Unit tests for `assign_colors()`:
+   - Green: favorable/neutral + confidence >= threshold + no Amber triggers
+   - Red: unfavorable + confidence >= threshold + no Amber triggers
+   - Amber: low confidence, QA disagree, QA uncertain, error, grounding failure, grounding uncertain
+   - Edge cases: empty list, threshold at boundary (0.5 exactly), all triggers simultaneously
+   - Performance: 1,000 clauses in <100 ms
+   - Determinism: identical output for identical input
+2. Integration tests:
+   - `--confidence-threshold` flag acceptance and rejection of invalid values
+   - Different thresholds producing different color distributions
+   - JSON output format with `color`, `amber_reasons`, `effective_confidence`, `confidence_threshold`
+   - Terminal rendering with three-color badges
+   - Empty assessment list
+   - Backward compat: `is_amber` still accessible
+   - Help text includes accuracy ceiling disclosure
+
+## Complexity Tracking
+
+None — all 5 constitution principles pass. No violations to justify.

--- a/specs/013-three-color-confidence/quickstart.md
+++ b/specs/013-three-color-confidence/quickstart.md
@@ -1,0 +1,164 @@
+# Quickstart: Three-Color Output with Confidence Scores
+
+**Spec**: 013 — Three-Color Output with Confidence Scores
+**Date**: 2026-07-03
+
+---
+
+## Validation Scenarios
+
+### Scenario 1 — Default Threshold (0.7)
+
+**Setup**: Run a single-party review on an NDA without the `--confidence-threshold` flag.
+
+```bash
+openreview precheck review tests/fixtures/simple-nda.pdf --playbook precheck-nda-v1
+```
+
+**Expected**:
+- Terminal output shows Green/Amber/Red badges in the Status column
+- Clauses with favorable position and confidence >= 0.7 are Green
+- Clauses with unfavorable position and confidence >= 0.7 are Red
+- Clauses with confidence < 0.7 or QA disagreement are Amber with `⚠ AMBER` badge
+- Summary shows `Green: N`, `Amber: N`, `Red: N`
+
+**Pass condition**: Three distinct colors visible in terminal output. No binary OK/AMBER remaining.
+
+---
+
+### Scenario 2 — Custom Threshold
+
+**Setup**: Same review, run twice with different thresholds.
+
+```bash
+openreview precheck review tests/fixtures/simple-nda.pdf \
+  --playbook precheck-nda-v1 \
+  --confidence-threshold 0.9
+
+openreview precheck review tests/fixtures/simple-nda.pdf \
+  --playbook precheck-nda-v1 \
+  --confidence-threshold 0.3
+```
+
+**Expected**:
+- `0.9` threshold produces **more** Amber flags than default (0.7)
+- `0.3` threshold produces **fewer** Amber flags than default (0.7)
+- Both run in under 1 second (no pipeline re-run)
+
+**Pass condition**: Different threshold values produce observably different color distributions. No pipeline re-run (assessments unchanged, only colors change).
+
+---
+
+### Scenario 3 — JSON Output
+
+**Setup**: Run with `--output json`.
+
+```bash
+openreview precheck review tests/fixtures/simple-nda.pdf \
+  --playbook precheck-nda-v1 \
+  --output json
+```
+
+**Expected**:
+- Each assessment has `"color"` field: `"green"`, `"amber"`, or `"red"`
+- Each assessment has `"amber_reasons"` field (list of strings, empty for Green/Red)
+- Each assessment has `"effective_confidence"` field (float)
+- Each assessment has `"is_amber"` field (boolean, derived from color) — backward compat
+- Report root has `"confidence_threshold": 0.7`
+- Summary has `"green_count"`, `"red_count"`, `"avg_effective_confidence"`
+
+**Pass condition**: All new fields present in JSON output. `is_amber` is consistent with `color`.
+
+---
+
+### Scenario 4 — All Green (Edge)
+
+**Setup**: All clauses are favorable/neutral with confidence >= 0.7, no errors, QA agrees, grounding passes (or no grounding data).
+
+```bash
+openreview precheck review tests/fixtures/all-safe-nda.pdf \
+  --playbook precheck-nda-v1
+```
+
+**Expected**:
+- Every clause shows Green badge
+- Summary shows `Green: N, Amber: 0, Red: 0`
+- No `⚠ AMBER` badges visible
+
+**Pass condition**: Zero Amber, zero Red. User sees all safe.
+
+---
+
+### Scenario 5 — Low Confidence Amber (Edge)
+
+**Setup**: A clause has confidence 0.4 with favorable position, QA agrees, no errors.
+
+```bash
+openreview precheck review tests/fixtures/low-conf-nda.pdf \
+  --playbook precheck-nda-v1
+```
+
+**Expected**:
+- The low-confidence clause shows Amber badge
+- Amber reason includes `low_confidence`
+- Reason text shows "Below confidence threshold (0.40 < 0.70)"
+
+**Pass condition**: Low confidence alone triggers Amber. User can see why.
+
+---
+
+### Scenario 6 — Backward Compatibility
+
+**Setup**: Code that reads `ca.is_amber` directly.
+
+```python
+for assessment in report.assessments:
+    if assessment.is_amber:
+        print(f"Clause {assessment.clause_id} needs review")
+```
+
+**Expected**:
+- `is_amber` returns `True` for Amber assessments (whether accessed before or after `assign_colors()`)
+- `is_amber` returns `False` for Green and Red assessments
+- `amber_count` in summary still works
+
+**Pass condition**: Existing code that checks `is_amber` or `amber_count` continues to function unchanged.
+
+---
+
+### Scenario 7 — Help Text Disclosure
+
+**Setup**: Run `--help` on a review subcommand.
+
+```bash
+openreview precheck review --help
+```
+
+**Expected**:
+- `--confidence-threshold` appears in the help output
+- Help text includes the accuracy ceiling disclosure:
+  ```
+  Note: The comparison accuracy of automated review is bounded by
+  approximately 64% F1. Three-color output (Green/Amber/Red) is
+  designed to mitigate this — set the threshold generously to push
+  uncertain comparisons to Amber rather than risking false Green or Red.
+  ```
+
+**Pass condition**: Help text contains the disclosure. Verified by grepping the help output or the source string.
+
+---
+
+## Quick Verification Commands
+
+```bash
+# 1. Verify the flag is accepted and help text includes disclosure
+openreview precheck review --help | grep -i "confidence-threshold"
+
+# 2. Verify invalid values are rejected
+openreview precheck review test.pdf --playbook precheck-nda-v1 --confidence-threshold 1.5 \
+  && echo "SHOULD HAVE FAILED" || echo "Correctly rejected"
+
+# 3. Verify JSON output has new fields
+openreview precheck review test.pdf --playbook precheck-nda-v1 --output json \
+  | python -c "import sys,json; d=json.load(sys.stdin); print('color' in d['assessments'][0])"
+```

--- a/specs/013-three-color-confidence/research.md
+++ b/specs/013-three-color-confidence/research.md
@@ -1,0 +1,116 @@
+# Research: Three-Color Output with Confidence Scores
+
+**Spec**: 013 — Three-Color Output with Confidence Scores
+**Date**: 2026-07-03
+
+---
+
+## R1: Three-Color Output Patterns in Legal Tech
+
+**Question**: What is the established UX pattern for displaying assessment confidence in legal document review tools?
+
+### Findings
+
+The traffic-light model (Green/Amber/Red) is the de facto standard across legal technology:
+
+- **Kira Systems, Luminance, eBrevia, LawGeex**: All use Green-Amber-Red (or equivalent checkmark-warning-cross) to indicate clause risk. The pattern matches the mental model of "stoplight" that legal professionals use in manual review.
+- **Amber as escape hatch**: In every major platform, Amber ("requires human review") is the most important signal — it is where the system concedes uncertainty rather than making a false high-confidence prediction.
+- **Binary (pass/fail) limitations**: Binary output forces the user into a false dichotomy. Legal review requires a middle state because automated comparison accuracy has a known ceiling (cite §6.4: ~64% F1). Amber is the mitigation for that ceiling.
+
+### Decision
+
+Use a three-state `AssessmentColor` enum (Green/Amber/Red). Do not extend to four states — §6.4 explicitly calls for three-color output and neutral + high confidence maps to Green (FR-011). This matches the legal-tech industry standard and the project's own §6.4 requirements.
+
+---
+
+## R2: Confidence Threshold Design
+
+**Question**: Single global threshold vs. per-stage thresholds? What value should the default be?
+
+### Findings
+
+- **Single global threshold**: Simplest UX. One knob the user turns. No cognitive overhead of tuning per-stage thresholds. §6.4 mandates a single `--confidence-threshold` flag.
+- **Per-stage thresholds**: More flexible but harder to explain and test. Not warranted until users explicitly ask for it. (YAGNI — Principle V.)
+- **Default value**: §6.4 says "set Amber threshold generously." Industry benchmarks for clause classification (LexNLP, LawGeex benchmarks) show optimal F1 at thresholds around 0.6-0.8. 0.7 is generous — meaning it will err on the side of "human review needed" (Amber) rather than false Green/Red. The spec confirms this in FR-012.
+- **Range validation**: Any float in [0.0, 1.0] is valid. 0.0 means "all non-erroneous assessments pass" (essentially Amber only on error/QA-disagree). 1.0 means "only assessments with perfect confidence pass" — virtually everything Amber.
+
+### Decision
+
+Single global threshold, float in [0.0, 1.0], default 0.7. CLI accepts via `--confidence-threshold` flag. Typer callback validates the range and rejects out-of-range values with a clear error message.
+
+---
+
+## R3: Confidence Aggregation Strategy
+
+**Question**: How to combine extraction confidence, QA confidence, and grounding confidence into a single "effective confidence"?
+
+### Options Considered
+
+| Strategy | Formula | Behavior |
+|----------|---------|----------|
+| **Min** (selected) | `min(extraction, qa, grounding)` | Most conservative. Any low-confidence stage → low effective confidence → Amber. |
+| Weighted average | `w1*ext + w2*qa + w3*gnd` | Requires tuning weights. Can mask a single failed stage if other stages are high. |
+| Product | `ext * qa * gnd` | Punishes multiple moderate confidences very hard (0.8 * 0.8 * 0.8 = 0.51). Too aggressive. |
+| Max | `max(extraction, qa, grounding)` | Too permissive. Hides failures. |
+
+### Decision
+
+Use **min()** across available stages. Missing stages default to 1.0 (no penalty). The rule:
+```
+effective_confidence = min(
+    extraction_confidence or 1.0,
+    qa_confidence or 1.0,
+    grounding_confidence or 1.0
+)
+```
+
+This matches the §6.4 "generous Amber" philosophy — any single stage expressing doubt drives the assessment to Amber. It is trivially correct (a chain is only as strong as its weakest link) and requires no tuning.
+
+---
+
+## R4: CLI Flag Design for Typer
+
+**Question**: How to expose `--confidence-threshold` on review-producing subcommands in a Typer app?
+
+### Findings
+
+- **Typer Option pattern**: `typer.Option(default, help=..., min=..., max=..., clamp=...)` — built-in validation.
+- **Per-command flag**: Each review subcommand (`precheck`, `hirecheck`, etc.) gets its own `--confidence-threshold` flag. The flag is on the command, not the app — this matches FR-013 ("per-command with shared default").
+- **Shared default constant**: Define `DEFAULT_CONFIDENCE_THRESHOLD = 0.7` in one place (e.g., `review/__init__.py` or `app.py` — ponytail: put it where it's first used, `app.py`). Each command imports and uses it.
+- **Help text**: Must include the accuracy ceiling disclosure (FR-008) — that text belongs in the `help=` parameter of `typer.Option()`.
+- **Backward compat**: Commands that don't accept the flag (non-review commands) remain unchanged.
+
+### Typer Code Pattern
+
+```python
+import typer
+from openreview_cli.app import DEFAULT_CONFIDENCE_THRESHOLD
+
+def _validate_threshold(value: float) -> float:
+    if not 0.0 <= value <= 1.0:
+        raise typer.BadParameter(f"confidence-threshold must be between 0.0 and 1.0, got {value}")
+    return value
+
+@review_app.command("precheck")
+def precheck_review(
+    ...,
+    confidence_threshold: float = typer.Option(
+        DEFAULT_CONFIDENCE_THRESHOLD,
+        "--confidence-threshold",
+        help="Confidence threshold for Green/Amber/Red assignment "
+             "(0.0-1.0). Note: The comparison accuracy of automated review "
+             "is bounded by approximately 64% F1. Three-color output "
+             "(Green/Amber/Red) is designed to mitigate this — set the "
+             "threshold generously to push uncertain comparisons to Amber "
+             "rather than risking false Green or Red.",
+        min=0.0,
+        max=1.0,
+        callback=_validate_threshold,
+    ),
+):
+    ...
+```
+
+### Decision
+
+Per-command flag using standard Typer `Option` with `min`/`max` constraint and a callback for custom validation. Default value from a shared constant. Help text includes the §6.4/CON-1 accuracy ceiling disclosure.

--- a/specs/013-three-color-confidence/spec.md
+++ b/specs/013-three-color-confidence/spec.md
@@ -1,0 +1,200 @@
+# Feature Specification: Three-Color Output with Confidence Scores
+
+**Feature Branch**: `013-three-color-confidence`
+
+**Created**: 2026-07-03
+
+**Status**: Draft
+
+**Input**: Blueprint §11 seed — "Three-color output with confidence scores. User-configurable `--confidence-threshold` flag."
+
+**Blueprints**: N-6 (§7, line 425), §6.4 (lines 334–344), R-6 (§8, line 464), Q-8 (§10, lines 613–627), CON-1, R-1, R-11, P-4
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — Legal professional reads a Green/Amber/Red review at a glance (Priority: P1)
+
+A legal professional runs a single-party review on an NDA. Instead of scanning every clause detail, they see the output color-coded: Green (safe — proceed), Amber (uncertain — check manually), Red (problematic — needs attention). They immediately know which clauses are safe and which need human review, without reading through every assessment.
+
+**Why this priority**: The three-color signal is the primary mitigation for the comparison accuracy ceiling (§6.4, CON-1). Without it, the user cannot distinguish high-confidence from uncertain assessments at a glance. This is the core value of the feature.
+
+**Independent Test**: Can be fully tested by running a review with known clause assessments and verifying the terminal output shows the correct color for each clause (Green/Amber/Red) in the Status column.
+
+**Acceptance Scenarios**:
+
+1. **Given** a review with 10 clause assessments, 5 of which are favorable + high confidence, 3 uncertain + low confidence, and 2 unfavorable + high confidence, **When** the report is rendered in the terminal, **Then** the Status column shows Green, Amber, Red respectively with distinct visual styling.
+2. **Given** a review where all clauses are favorable with confidence ≥ threshold, **When** the report is rendered, **Then** all clauses show Green status.
+3. **Given** a review where all clauses are uncertain or have confidence < threshold, **When** the report is rendered, **Then** all clauses show Amber status with the `⚠ AMBER` indicator.
+
+---
+
+### User Story 2 — Legal professional adjusts confidence threshold (Priority: P1)
+
+A legal professional wants fewer Amber flags because they trust the model, so they run with `--confidence-threshold 0.3`. Conversely, a risk-averse professional wants more Amber flags and runs with `--confidence-threshold 0.8`. In both cases, the output is recalculated without re-running extraction, QA, or grounding. The user sees the effect immediately.
+
+**Why this priority**: User-configurable threshold is listed as a hard requirement in the blueprint seed (§11). It directly addresses the "set Amber threshold generously" mandate from §6.4 and R-6, and it is the mechanism through which users adapt the tool to their risk tolerance.
+
+**Independent Test**: Can be fully tested by running the same review twice with different `--confidence-threshold` values and verifying the color distributions differ.
+
+**Acceptance Scenarios**:
+
+1. **Given** a review with 10 clause assessments, **When** the user runs with `--confidence-threshold 0.9`, **Then** the number of Amber flags is greater than or equal to the number at the default threshold (0.7).
+2. **Given** the same review, **When** the user runs with `--confidence-threshold 0.3`, **Then** the number of Amber flags is less than or equal to the number at the default threshold (0.7).
+3. **Given** a review run with `--confidence-threshold 0.9`, **When** the output is rendered, **Then** a clause with confidence 0.85 must be Amber (confidence < threshold).
+
+---
+
+### User Story 3 — Legal professional inspects why a clause is Amber (Priority: P2)
+
+A senior attorney sees a clause marked Amber and wants to understand why before deciding whether to override. They inspect the assessment details and can see: which stage triggered the Amber flag (low extraction confidence, QA disagreement, grounding failure), the individual confidence scores from each stage, and the specific reason (e.g., "QA agent disagreed: position should be unfavorable").
+
+**Why this priority**: Transparency drives trust. Without it, users cannot distinguish a "barely Amber" clause (confidence 0.49, near the boundary) from a "deeply Amber" one (confidence 0.1 with QA disagreement and grounding failure). P2 because the core three-color output (P1) is functional without it, but professional users will not trust an opaque Amber flag.
+
+**Independent Test**: Can be fully tested by running a review where a clause is deliberately made Amber (low confidence, QA disagree, or error) and verifying the breakdown is visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clause assessment where extraction confidence = 0.4 and QA disagrees, **When** the user inspects the breakdown, **Then** they see both the low extraction confidence and QA disagreement as separate triggers.
+2. **Given** a clause assessment that is Amber due to grounding failure (grounding_verdict = UNGROUNDED), **When** the user inspects the breakdown, **Then** they see the grounding failure listed as the trigger.
+3. **Given** a clause assessment that is Amber solely because confidence is below the user-configured threshold, **When** the user inspects the breakdown, **Then** they see "Below confidence threshold (0.49 < 0.5)" as the reason.
+
+---
+
+### User Story 4 — Developer validates threshold behavior across edge cases (Priority: P3)
+
+A developer tests the three-color system by passing extreme `--confidence-threshold` values (0.0 and 1.0) and reviewing assessment lists that are empty, all Amber, or single-clause. The system handles all boundary conditions gracefully without crashing or producing ambiguous output.
+
+**Why this priority**: Threshold boundary behavior is critical for correctness but does not deliver user-facing value until the first three stories are implemented.
+
+**Independent Test**: Can be fully tested by running the system with edge-case threshold values and verifying correct color assignment.
+
+**Acceptance Scenarios**:
+
+1. **Given** a review with `--confidence-threshold 0.0`, **When** the report is rendered, **Then** no clause is Amber due to confidence threshold (all pass), and only QA disagreement/error/grounding failure triggers Amber.
+2. **Given** the same review with `--confidence-threshold 1.0`, **When** the report is rendered, **Then** every clause with confidence < 1.0 is Amber, and only perfect assessments are Green/Red.
+3. **Given** an empty assessment list, **When** the report is rendered, **Then** the output shows "No clauses to assess" without error.
+4. **Given** `--confidence-threshold 0.5`, **When** a clause has confidence exactly 0.5, **Then** it is NOT Amber from the threshold alone (confidence >= threshold; `confidence < 0.5` is the trigger, so 0.5 passes).
+
+---
+
+### Edge Cases
+
+- **Threshold at exact boundary (0.5)**: A clause with confidence exactly 0.500 must be treated as passing (Green/Red if no other trigger), not Amber. The rule is `confidence < threshold`, not `confidence <= threshold`.
+- **Threshold values outside [0.0, 1.0]**: The CLI must reject values outside the valid range with a clear error message.
+- **Clause with all Amber triggers**: A clause where confidence is low, QA disagrees, and grounding fails must show Amber once (not triplicate the indicator). All contributing reasons are visible in the breakdown (US3), but the status is a single Amber.
+- **No grounding data present**: When grounding is not available (e.g., discriminator not run), grounding failure must not trigger Amber. Only defined Amber triggers apply.
+- **Mixed QA outcomes across multiple QA passes**: If QA disagrees on one round but subsequent passes agree, the final verdict determines Amber — not intermediate states.
+- **Performance with many clauses**: The three-color computation must not add measurable latency — it is a stateless deterministic mapping that runs in O(n) with no external calls.
+- **CLI flag precedence**: `--confidence-threshold` applies at the command level that generates review output (e.g., `precheck`, `hirecheck`), not globally. Each command that produces a `ReviewReport` MUST accept the flag.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST assign each `ClauseAssessment` a three-color status (Green/Amber/Red) computed from the combined position, confidence, QA verdict, grounding verdict, and user-configured threshold. The color is a derived property — it is not stored but computed at output time. The computation is O(n) and introduces no external calls. [N-6][§6.4]
+
+- **FR-002**: Color assignment rules:
+  - **Green**: Position is favorable or neutral AND confidence >= threshold AND no Amber trigger is active.
+  - **Red**: Position is unfavorable AND confidence >= threshold AND no Amber trigger is active.
+  - **Amber** (everything else): Position is uncertain, OR confidence < threshold, OR QA verdict is disagree or uncertain, OR error is present, OR grounding verdict is ungrounded or uncertain.
+  - These rules supersede the current hardcoded `is_amber` logic in `ClauseAssessment.__post_init__` (which unconditionally uses 0.5 as threshold). The threshold becomes configurable, and the color enum replaces the boolean flag. [§6.4][CON-1][R-11]
+
+- **FR-003**: System MUST expose a `--confidence-threshold` CLI flag on every review-producing subcommand (`precheck`, `hirecheck`, etc.). The flag accepts a float in [0.0, 1.0], defaulting to 0.7. Values outside the range MUST be rejected with a clear error message. [N-6][R-6]
+
+- **FR-004**: Amber triggers are defined as: extraction confidence < threshold; QA verdict is `disagree` or `uncertain`; assessment has a non-None error; grounding verdict is `ungrounded` or `uncertain`. Each trigger is evaluated independently — any single trigger makes the assessment Amber. Grounding is only a trigger when grounding data exists (grounding_verdict is not None). [§6.4][R-11]
+
+- **FR-005**: The three-color status MUST be rendered in terminal output via a dedicated color indicator (distinct from the position color) in the Status column. The existing `⚠ AMBER` / `OK` representation MUST be replaced with a three-state indicator: Green badge, Amber badge with warning symbol, Red badge. [Q-8]
+
+- **FR-006**: JSON output MUST include a `"color"` field on each `ClauseAssessment` with one of `"green"`, `"amber"`, `"red"`. The existing `is_amber` boolean field in JSON output MUST be deprecated in favor of the three-state field. [Q-8]
+
+- **FR-007**: The color computation MUST be a pure stateless mapping from existing assessment fields — it MUST NOT require re-running extraction, QA, or grounding. Changing `--confidence-threshold` must produce output instantaneously (sub-second for any reasonable number of clauses). [§6.4]
+
+- **FR-008**: User-facing help text for `--confidence-threshold` MUST include a disclosure of the comparison accuracy ceiling: "Note: The comparison accuracy of automated review is bounded by approximately 64% F1. Three-color output (Green/Amber/Red) is designed to mitigate this — set the threshold generously to push uncertain comparisons to Amber rather than risking false Green or Red." [CON-1][R-1]
+
+- **FR-009**: The `AssessmentColor` enum (Green/Amber/Red) MUST be a first-class entity in the review data model, replacing the boolean `is_amber` flag as the primary color signal. The `is_amber` flag MAY be retained as a derived convenience property (`is_amber == (color == AssessmentColor.AMBER)`) for backwards compatibility with existing consumers of `ReviewSummary.amber_count`. [N-6][§6.4]
+
+- **FR-010**: The ReviewSummary MUST include a three-color breakdown count (green_count, amber_count, red_count) in addition to the existing position breakdown. The existing `amber_count` is preserved as a derived property from `amber_count`. [Q-8]
+
+- **FR-011**: Neutral position with confidence ≥ threshold maps to Green. Neutral position with confidence < threshold maps to Amber. This is a three-color system (not four-color): neutral with high confidence is treated as "safe to proceed" (Green). [§6.4]
+
+- **FR-012**: Default confidence threshold is 0.7. Users may override via `--confidence-threshold` flag. The 0.7 default implements the "set Amber threshold generously" mandate from §6.4 and the accuracy ceiling mitigation from R-6. [§6.4][R-6]
+
+- **FR-013**: The `--confidence-threshold` flag is per-command (e.g., `openreview precheck --confidence-threshold 0.8`). Each review subcommand accepts the flag independently with a shared default of 0.7. Mode-specific defaults are a future option. [§6.4]
+
+### Key Entities
+
+- **AssessmentColor**: An enumeration with three values — `GREEN`, `AMBER`, `RED`. Represents the final color-assigned verdict for a single clause assessment. Derived deterministically from position, confidence, QA verdict, error, grounding verdict, and the user-configured threshold. Replaces the boolean `is_amber` as the primary color signal. A convenience property `is_amber` MAY be retained on `ClauseAssessment` for backwards compatibility, defined as `is_amber == (color == AMBER)`.
+
+- **ConfidenceThreshold**: A single float value in [0.0, 1.0] that controls the boundary between high-confidence (Green/Red) and low-confidence (Amber) assessments. Default is 0.7. Provided per-command via `--confidence-threshold` CLI flag. The threshold affects color assignment only — it does not change extraction, QA, or grounding behavior. [§6.4][R-6]
+
+### Integration Points
+
+- **Input**: The three-color computation consumes existing `ClauseAssessment` fields (position, confidence, qa_verdict, error, grounding_verdict) plus the user-provided `--confidence-threshold`. All inputs are already available after the review pipeline (extraction → QA → grounding) completes.
+
+- **Output**: The three-color status appears in:
+  - **Terminal table** (Rich): Status column shows a colored badge (Green/Amber/Red) replacing the current `⚠ AMBER` / `OK` binary. Position column retains its existing per-position coloring (favorable=green, neutral=yellow, unfavorable=red, uncertain=bold red).
+  - **JSON output**: Each assessment gains a `"color"` field. The existing `is_amber` field may be retained as a derived boolean for backwards compatibility.
+
+- **Relationship to existing `is_amber`**: The current `is_amber` boolean is set in `ClauseAssessment.__post_init__` with a hardcoded 0.5 threshold. Spec 013 replaces this with a configurable threshold and a three-state color enum. Implementation must either:
+  - (A) Modify `__post_init__` to accept a threshold parameter, or
+  - (B) Make color a computed property at output time (not stored on the instance).
+
+  Resolution (B) is recommended: it ensures threshold changes can be applied without re-serializing assessments, and it keeps the assessment data model clean. The spec does not mandate HOW — only WHAT the color output must be.
+
+- **CLI integration**: Every review-producing subcommand (currently `precheck` in app.py) must accept `--confidence-threshold`. The flag is applied when rendering output, not during the pipeline run (no re-run needed).
+
+---
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A user can pass `--confidence-threshold 0.7` and `--confidence-threshold 0.3` on the same review and observe different color distributions in the output, with 0.7 producing more Amber flags than 0.3. The output for both invocations is produced in under 1 second for a 100-clause review (no pipeline re-run). [N-6][§6.4]
+
+- **SC-002**: Every clause assessment in terminal output shows one of three distinct color badges (Green/Amber/Red) in the Status column. JSON output includes a `"color"` field on every assessment. Zero assessments fail to render a color. [Q-8]
+
+- **SC-003**: User-facing help text for `--confidence-threshold` includes the accuracy ceiling disclosure (§6.4, CON-1) and a recommendation to set the threshold generously. Verified by grepping the help text. [CON-1][R-1]
+
+- **SC-004**: Given a list of 1,000 clause assessments with known positions and confidences, the color assignment function returns correct colors for all 1,000 in under 100 ms. Verified with a unit test. [§6.4]
+
+- **SC-005**: The color computation is stateless and produces identical output for identical input, regardless of invocation order, system state, or number of calls. Verified by running the same computation twice and comparing results. [§6.4]
+
+- **SC-006**: A review with all assessments marked Amber (due to low confidence, QA disagreement, and errors) renders without visual conflicts — each Amber badge is distinct and readable, no color clashes. [Q-8]
+
+- **SC-007**: When `--confidence-threshold` is not specified, the system uses the default threshold and produces consistent output. When an invalid value (e.g., `1.5` or `-0.1`) is passed, the CLI exits with a clear error message and non-zero exit code. [N-6]
+
+---
+
+## Assumptions
+
+- **Neutral positions map to Green**: When a neutral position has confidence ≥ threshold and no Amber triggers are active, the assessment is Green (low-risk). This matches the three-color model from §6.4 and CON-1, where Green means "safe to proceed" and neutral with high confidence is safe. [FR-011][§6.4]
+
+- **Color is derived at output time, not stored**: The three-color status is computed when rendering terminal/JSON output, not stored on the `ClauseAssessment` dataclass. This allows threshold changes without re-processing assessments and keeps the data model clean. The `AssessmentColor` enum may appear transiently during rendering but is not persisted.
+
+- **Default confidence threshold is 0.7**: Per §6.4 guidance to "set Amber threshold generously" and R-6 accuracy ceiling mitigation. Users may override via `--confidence-threshold` on any review subcommand. [FR-012][§6.4][R-6]
+
+- **Single-party review only (v1)**: The three-color output integrates with the single-party review pipeline (spec 011). Multi-party review (future) and other product modes will add `--confidence-threshold` when they are specified.
+
+- **`is_amber` backwards compatibility**: The existing `is_amber` boolean and `amber_count` in `ReviewSummary` are preserved as derived properties for consumers that depend on them (e.g., `app.py` line 501 which checks `amber_count > 0`). This avoids breaking changes to existing CLI behavior or integrations.
+
+- **Existing QA and grounding pipelines unchanged**: The three-color computation reads from existing fields but does not modify extraction, QA, or grounding logic. The `threshold` parameter in `ReviewCommand` (currently used for PII) remains separate from the `--confidence-threshold` for review colors — they are independent configuration knobs.
+
+- **Hardware budget not impacted**: The color computation is a deterministic O(n) mapping with no external calls, no new dependencies, and no memory allocation proportional to document size beyond the existing assessment list. It stays well within the 100 MB peak memory budget.
+
+- **CLI scope**: `--confidence-threshold` is per-command (e.g., `openreview precheck --confidence-threshold 0.7`), not global. Each review-producing mode accepts the flag independently with a shared default of 0.7. Mode-specific defaults are a future option. [FR-013][§6.4]
+
+---
+
+## Resolved Clarifications
+
+The following [NEEDS CLARIFICATION] items were resolved via `/speckit.clarify`:
+
+1. **FR-011 — Neutral color mapping**: Neutral + high confidence → Green (three-color, not four-color). [§6.4]
+2. **FR-012 — Default threshold**: 0.7 (generous, per §6.4 "set Amber threshold generously"). [§6.4][R-6]
+3. **FR-013 — Flag scope**: Per-command with shared 0.7 default. [§6.4]
+
+All three clarifications are reflected in the functional requirements and assumptions above. The spec is ready for planning.

--- a/specs/013-three-color-confidence/tasks.md
+++ b/specs/013-three-color-confidence/tasks.md
@@ -1,0 +1,561 @@
+---
+description: "Dependency-ordered task list for the Three-Color Output with Confidence Scores feature (N-6). Replaces binary amber/ok with Green/Amber/Red status, adds a user-configurable --confidence-threshold CLI flag, and shows amber reason breakdowns."
+---
+
+# Tasks: Three-Color Output with Confidence Scores (N-6)
+
+**Input**: Design documents from `specs/013-three-color-confidence/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cli-interface.md, quickstart.md
+
+**Tests**: TDD — tests MUST be written BEFORE the implementation they cover. Each test file starts as a failing test suite.
+
+**Organization**: Tasks are grouped by user story. Each story is independently implementable and testable. US1 and US2 are P1 and form the MVP. US3 (P2) extends the display with amber reason breakdowns. US4 (P3) validates edge cases.
+
+**Naming convention**: Existing review unit tests use flat naming (`tests/unit/test_review_models.py`, `tests/unit/test_review_report.py`). New test files follow the same flat pattern: `tests/unit/test_three_color_models.py`, `tests/unit/test_three_color_report.py`, `tests/unit/test_three_color_cli.py`. No `tests/unit/review/` subdirectory.
+
+---
+
+## Phase 1: Foundational — Data Models & Color Logic (Blocking Prerequisites)
+
+**Purpose**: Core data model enums (`AssessmentColor`, `AmberReason`), the `assign_colors()` pure function, and updates to `ClauseAssessment`, `ReviewSummary`, and `ReviewReport`. ALL user stories depend on these modules being complete.
+
+**⚠ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] **T001** Write unit tests for `AssessmentColor` and `AmberReason` enums in `tests/unit/test_three_color_models.py`:
+  - `AssessmentColor` has values `green`, `amber`, `red` (StrEnum)
+  - `AmberReason` has values `low_confidence`, `qa_disagreement`, `qa_uncertain`, `error`, `grounding_failure`, `grounding_uncertain` (StrEnum)
+  - Enums are proper `StrEnum` subclasses (comparable to strings, JSON-serializable)
+  - Match enum test patterns from existing `test_review_models.py` (`Position`, `QAVerdict`)
+  - **FR reference**: FR-009
+  - **File paths**: `tests/unit/test_three_color_models.py`
+  - **Dependencies**: None
+  - **Complexity**: S
+
+- [ ] **T002** Implement `AssessmentColor(StrEnum)` and `AmberReason(StrEnum)` in `src/openreview_cli/review/colors.py`:
+  - Define `class AssessmentColor(StrEnum):` with `green = "green"`, `amber = "amber"`, `red = "red"`
+  - Define `class AmberReason(StrEnum):` with `low_confidence = "low_confidence"`, `qa_disagreement = "qa_disagreement"`, `qa_uncertain = "qa_uncertain"`, `error = "error"`, `grounding_failure = "grounding_failure"`, `grounding_uncertain = "grounding_uncertain"`
+  - Match existing enum patterns in `models.py` (`Position`, `QAVerdict`)
+  - **FR reference**: FR-009
+  - **File paths**: `src/openreview_cli/review/colors.py` (NEW)
+  - **Dependencies**: T001
+  - **Complexity**: S
+
+- [ ] **T003** Write unit tests for `assign_color()` function in `tests/unit/test_three_color_models.py`:
+  - **Green**: favorable + confidence >= threshold + no Amber triggers → `AssessmentColor.green`
+  - **Green**: neutral + confidence >= threshold + no Amber triggers → `AssessmentColor.green` (FR-011)
+  - **Red**: unfavorable + confidence >= threshold + no Amber triggers → `AssessmentColor.red`
+  - **Amber**: confidence < threshold (low_confidence trigger) → `AssessmentColor.amber`
+  - **Amber**: QA disagree → `AssessmentColor.amber` with `qa_disagreement` reason
+  - **Amber**: QA uncertain → `AssessmentColor.amber` with `qa_uncertain` reason
+  - **Amber**: error present → `AssessmentColor.amber` with `error` reason
+  - **Amber**: grounding ungrounded → `AssessmentColor.amber` with `grounding_failure` reason
+  - **Amber**: grounding uncertain → `AssessmentColor.amber` with `grounding_uncertain` reason
+  - **Amber**: uncertain position (no other trigger) → `AssessmentColor.amber` (ambiguous)
+  - **Multiple triggers**: all applicable `AmberReason` values in `amber_reasons` list
+  - **No grounding data**: grounding_verdict is None → grounding NOT a trigger (FR-004)
+  - **Edge cases**: empty assessment list (returns empty list), threshold at boundary (`0.5` — must use `<` not `<=`), all triggers simultaneously (still single Amber status)
+  - Performance: 1,000 assessments in <100 ms (SC-004)
+  - Determinism: identical output for identical input (SC-005)
+  - Pure function: no side effects, no I/O (FR-007)
+  - **FR reference**: FR-001, FR-002, FR-004, FR-007, FR-011, FR-003
+  - **File paths**: `tests/unit/test_three_color_models.py`
+  - **Dependencies**: T002
+  - **Complexity**: M
+
+- [ ] **T004** Implement `assign_colors()` function in `src/openreview_cli/review/colors.py`:
+  - Signature: `assign_colors(assessments: list[ClauseAssessment], threshold: float = 0.7) -> None`
+  - Pure function: mutates assessments in-place (sets `color`, `effective_confidence`, `amber_reasons`)
+  - No I/O, no side effects, no external calls — O(n) deterministic mapping
+  - Call `_compute_effective_confidence()` per assessment (T006)
+  - Apply color rules per data-model.md §Color Assignment Rules
+  - Edge cases: empty list (no-op), assessments with already-set color (recompute)
+  - Respect: grounding is only a trigger when `grounding_verdict is not None` (FR-004)
+  - **FR reference**: FR-001, FR-002, FR-004, FR-007, FR-011, FR-003
+  - **File paths**: `src/openreview_cli/review/colors.py` (NEW)
+  - **Dependencies**: T003, T006 (effective_confidence), T002 (enums)
+  - **Complexity**: M
+
+- [ ] **T005** Write unit tests for `effective_confidence()` calculation in `tests/unit/test_three_color_models.py`:
+  - `effective_confidence = min(confidence or 1.0, grounding_confidence or 1.0)`
+  - Note: `qa_confidence` is not yet a field on `ClauseAssessment` — defaults to 1.0 (future spec)
+  - Only extraction confidence available: `min(0.8, 1.0)` = 0.8
+  - Both extraction and grounding confidence: `min(0.8, 0.6)` = 0.6
+  - Both missing (None): `min(1.0, 1.0)` = 1.0
+  - Extraction None, grounding 0.7: `min(1.0, 0.7)` = 0.7
+  - Grounding None, extraction 0.5: `min(0.5, 1.0)` = 0.5
+  - All stages at 1.0: effective confidence = 1.0
+  - Zero confidence: `min(0.0, 1.0)` = 0.0
+  - **FR reference**: FR-001
+  - **File paths**: `tests/unit/test_three_color_models.py`
+  - **Dependencies**: T002 (AmberReason enum for imports)
+  - **Complexity**: S
+
+- [ ] **T006** Implement `_compute_effective_confidence()` helper in `src/openreview_cli/review/colors.py`:
+  - `def _compute_effective_confidence(assessment: ClauseAssessment) -> float`
+  - `return min(assessment.confidence or 1.0, assessment.grounding_confidence or 1.0)`
+  - Note: `qa_confidence` is omitted because it's not yet a field on `ClauseAssessment` (noted as `# ponytail: qa_confidence not yet a field — future spec`)
+  - Used by `assign_colors()` (T004)
+  - **FR reference**: FR-001
+  - **File paths**: `src/openreview_cli/review/colors.py` (NEW)
+  - **Dependencies**: T005, T002 (import ClauseAssessment type)
+  - **Complexity**: S
+
+- [ ] **T007** Extend existing unit tests for updated `ClauseAssessment` in `tests/unit/test_review_models.py`:
+  - Test new fields: `color` defaults to `None`, `amber_reasons` defaults to `None`, `effective_confidence` defaults to `None`
+  - Test `is_amber` property: returns `True` when `color == AssessmentColor.amber`, `False` for green/red
+  - Test backward compat: existing consumers reading `ca.is_amber` before `assign_colors()` still work (falls back to stored `_is_amber`)
+  - Test existing `ClauseAssessment` instances (without new fields) still construct via original constructor signature
+  - Test serialization: `dataclasses.asdict()` includes new fields
+  - Test `__post_init__` still sets `is_amber` for pre-color consumers (no regression)
+  - **FR reference**: FR-009, FR-010
+  - **File paths**: `tests/unit/test_review_models.py`
+  - **Dependencies**: T002 (AssessmentColor enum)
+  - **Complexity**: M
+
+- [ ] **T008** Update `ClauseAssessment` dataclass in `src/openreview_cli/review/models.py`:
+  - Add `color: AssessmentColor | None = None` field
+  - Add `amber_reasons: list[AmberReason] | None = None` field
+  - Add `effective_confidence: float | None = None` field
+  - Rename stored `is_amber: bool = False` to `_is_amber: bool = False` (private)
+  - Add `@property is_amber` that returns `(self.color == AssessmentColor.amber)` when color is set, falls back to `self._is_amber` when color is None
+  - Import `AssessmentColor` and `AmberReason` from `openreview_cli.review.colors` using TYPE_CHECKING guard to avoid circular import
+  - Bump `ReviewReport.schema_version` from `"1.0.0"` to `"1.1.0"` (additive fields only)
+  - **FR reference**: FR-009, FR-010, FR-007
+  - **File paths**: `src/openreview_cli/review/models.py`
+  - **Dependencies**: T007, T002 (enum classes defined)
+  - **Complexity**: M
+
+- [ ] **T009** Extend existing unit tests for updated `ReviewSummary` in `tests/unit/test_review_models.py`:
+  - Test `green_count` default (0)
+  - Test `red_count` default (0)
+  - Test `avg_effective_confidence` default (0.0)
+  - Test `amber_count` preserved unchanged (backward compat)
+  - Test `ReviewReport` can construct with new `confidence_threshold` field
+  - Test `confidence_threshold` default (0.7)
+  - Test `schema_version` is `"1.1.0"` after T008 bump
+  - **FR reference**: FR-010, FR-007
+  - **File paths**: `tests/unit/test_review_models.py`
+  - **Dependencies**: T007 (ClauseAssessment tests done)
+  - **Complexity**: S
+
+- [ ] **T010** Update `ReviewSummary` and `ReviewReport` dataclasses in `src/openreview_cli/review/models.py`:
+  - `ReviewSummary` additions:
+    - `green_count: int = 0`
+    - `red_count: int = 0`
+    - `avg_effective_confidence: float = 0.0`
+    - Keep `amber_count: int = 0` unchanged (backward compat)
+  - `ReviewReport` addition:
+    - `confidence_threshold: float = 0.7`
+  - **FR reference**: FR-010, FR-007
+  - **File paths**: `src/openreview_cli/review/models.py`
+  - **Dependencies**: T009, T008 (ClauseAssessment updated)
+  - **Complexity**: S
+
+- [ ] **T011** Export new types and functions from `src/openreview_cli/review/__init__.py`:
+  - Add to `__all__`: `"AssessmentColor"`, `"AmberReason"`, `"assign_colors"`
+  - Add imports: `from openreview_cli.review.colors import AssessmentColor, AmberReason, assign_colors`
+  - **FR reference**: FR-009
+  - **File paths**: `src/openreview_cli/review/__init__.py`
+  - **Dependencies**: T004, T002
+  - **Complexity**: S
+
+**Checkpoint**: Foundation ready — `uv run pytest tests/unit/test_three_color_models.py tests/unit/test_review_models.py -v` all pass. User story implementation can now begin.
+
+---
+
+## Phase 2: US1 + US3 — Three-Color Output with Amber Breakdown (P1 + P2) 🎯 MVP
+
+**Goal**: Deliver the core three-color display in both terminal and JSON output. Amber reason breakdown (US3) is naturally bundled because reasons are displayed alongside the color in both output formats. The `assign_colors()` function is called before rendering to populate `color`, `amber_reasons`, and `effective_confidence`.
+
+**Independent Test**: Run a review with known clause assessments and verify terminal shows Green/Amber/Red badges in the Status column with correct colors. JSON output includes `"color"`, `"amber_reasons"`, `"effective_confidence"`, and `"confidence_threshold"` fields.
+
+- [ ] **T012** Write unit tests for three-color terminal rendering in `tests/unit/test_three_color_report.py`:
+  - Green assessment → Status shows green badge (`● OK` or similar green indicator)
+  - Amber assessment → Status shows amber badge (`⚠ AMBER` with yellow styling)
+  - Red assessment → Status shows red badge (`● RED` with red styling)
+  - Amber clause with reasons shows reason breakdown text (e.g., "Low confidence (0.45)")
+  - Multiple amber reasons shown together ("Low confidence (0.45), QA disagreement")
+  - Green/Red assessments have empty `amber_reasons` (not shown)
+  - Summary section shows `Green: N`, `Amber: N`, `Red: N` (replacing `Amber flags: N` primary display)
+  - Summary shows `Avg effective confidence: X.XX` and `Confidence threshold: X.X`
+  - Backward compat: `Amber flags: N` still present in summary
+  - Empty assessment list shows "No clauses to assess" without error
+  - No grounding data present → no grounding triggers in amber reasons
+  - **FR reference**: FR-005, FR-004, FR-010, FR-011
+  - **File paths**: `tests/unit/test_three_color_report.py` (NEW)
+  - **Dependencies**: T004, T008, T010 (models + colors exist)
+  - **Complexity**: M
+
+- [ ] **T013** Update `format_terminal()` in `src/openreview_cli/review/report.py`:
+  - Import `assign_colors`, `AssessmentColor` from `openreview_cli.review.colors`
+  - Call `assign_colors(report.assessments, report.confidence_threshold)` at the top of `format_terminal()`
+  - Replace binary status rendering (line 71):
+    ```python
+    # OLD:
+    status = "[bold red]⚠ AMBER[/bold red]" if ca.is_amber else "[dim]OK[/dim]"
+    # NEW:
+    if ca.color == AssessmentColor.green:
+        status = "[green]● OK[/green]"
+    elif ca.color == AssessmentColor.red:
+        status = "[bold red]● RED[/bold red]"
+    else:
+        status = "[bold yellow]⚠ AMBER[/bold yellow]"
+    ```
+  - Update Summary section (lines 86-102):
+    - Add `Green: {summary.green_count}` before `Amber:`
+    - Add `Red: {summary.red_count}` after Amber
+    - Add `Avg effective confidence: {summary.avg_effective_confidence:.2f}`
+    - Add `Confidence threshold: {report.confidence_threshold}`
+    - Keep `Amber flags: {summary.amber_count}` for backward compat
+  - Add amber reason detail row when `ca.amber_reasons` is non-empty (secondary line per clause or detail section after table)
+  - Ensure three-color computation does not add measurable latency (stateless O(n))
+  - **FR reference**: FR-005, FR-004, FR-010, FR-001
+  - **File paths**: `src/openreview_cli/review/report.py`
+  - **Dependencies**: T012, T011 (exports), T010 (ReviewReport.confidence_threshold)
+  - **Complexity**: M
+
+- [ ] **T014** Write unit tests for three-color JSON output in `tests/unit/test_three_color_report.py`:
+  - Each assessment has `"color"` field: `"green"`, `"amber"`, or `"red"`
+  - Each assessment has `"amber_reasons"` field: list of strings (empty for Green/Red)
+  - Each assessment has `"effective_confidence"` field: float or null
+  - Each assessment has `"is_amber"` field: boolean (derived from color, backward compat)
+  - Report root has `"confidence_threshold"`: 0.7 (default)
+  - Summary has `"green_count"`, `"red_count"`, `"avg_effective_confidence"`
+  - `"amber_count"` still present in summary (backward compat)
+  - `"schema_version"` is `"1.1.0"`
+  - JSON output is valid JSON (parses with `json.loads`)
+  - `is_amber` is consistent with `color` (green → false, amber → true, red → false)
+  - **FR reference**: FR-006, FR-009, FR-010
+  - **File paths**: `tests/unit/test_three_color_report.py` (NEW)
+  - **Dependencies**: T012 (report test infra), T004 (colors exist)
+  - **Complexity**: M
+
+- [ ] **T015** Update `format_json()` and `_report_to_dict()` in `src/openreview_cli/review/report.py`:
+  - Import `assign_colors` from `openreview_cli.review.colors`
+  - In `format_json()` (or `_report_to_dict()`), call `assign_colors()` before serialization
+  - The new fields (`color`, `amber_reasons`, `effective_confidence`, `confidence_threshold`) are already included by `dataclasses.asdict()` after being populated by `assign_colors()`
+  - `is_amber` is still written as a field (backward compat) — it's a stored field on the dataclass
+  - `schema_version` is already `"1.1.0"` from T008
+  - Verify: JSON output shape matches cli-interface.md schema
+  - **FR reference**: FR-006, FR-009, FR-010
+  - **File paths**: `src/openreview_cli/review/report.py`
+  - **Dependencies**: T014, T013 (report formatting), T011 (exports)
+  - **Complexity**: M
+
+**Checkpoint**: MVP is shippable. Three-color terminal and JSON output work end-to-end. Amber reasons visible in both formats.
+
+---
+
+## Phase 3: US2 — Configurable Confidence Threshold (P1)
+
+**Goal**: Users can pass `--confidence-threshold` on any review subcommand to control the boundary between high-confidence (Green/Red) and low-confidence (Amber) assessments. Invalid values are rejected with clear errors. Help text includes the accuracy ceiling disclosure.
+
+**Independent Test**: Run the same review twice with `--confidence-threshold 0.9` and `--confidence-threshold 0.3`. The 0.9 run produces more Amber flags. Invalid values like `1.5` or `-0.1` are rejected.
+
+- [ ] **T016** Write unit tests for `--confidence-threshold` CLI flag in `tests/unit/test_three_color_cli.py`:
+  - Flag parses as float type
+  - Default value is 0.7
+  - Valid values: 0.0, 0.3, 0.5, 0.7, 0.9, 1.0 all accepted
+  - Invalid values: -0.1, 1.5, "abc" rejected with error message
+  - Validation callback: `0.0 <= value <= 1.0`
+  - Help text contains accuracy ceiling disclosure substring
+  - Help text mentions default of 0.7
+  - Flag is optional (omitting it uses default)
+  - Pattern matches existing Typer Option patterns in `app.py` (e.g., `--grounding-mode`)
+  - **FR reference**: FR-003, FR-008, FR-012, FR-013
+  - **File paths**: `tests/unit/test_three_color_cli.py` (NEW)
+  - **Dependencies**: None (pure CLI parsing tests, can mock the review command)
+  - **Complexity**: M
+
+- [ ] **T017** Add `--confidence-threshold` flag to the `precheck review` subcommand in `src/openreview_cli/app.py`:
+  - Define `DEFAULT_CONFIDENCE_THRESHOLD: float = 0.7` as a module-level constant in `app.py`
+  - Add `_validate_threshold(value: float) -> float` callback:
+    ```python
+    def _validate_threshold(value: float) -> float:
+        if not 0.0 <= value <= 1.0:
+            raise typer.BadParameter(
+                f"confidence-threshold must be between 0.0 and 1.0, got {value}"
+            )
+        return value
+    ```
+  - Add `confidence_threshold` parameter to `precheck review`:
+    ```python
+    confidence_threshold: float = typer.Option(
+        DEFAULT_CONFIDENCE_THRESHOLD,
+        "--confidence-threshold",
+        help="Confidence threshold for Green/Amber/Red assignment (0.0-1.0). "
+             "Clauses with effective confidence below this threshold are marked Amber. "
+             "Note: The comparison accuracy of automated review is bounded by "
+             "approximately 64% F1. Three-color output (Green/Amber/Red) is "
+             "designed to mitigate this — set the threshold generously to push "
+             "uncertain comparisons to Amber rather than risking false Green or Red.",
+        min=0.0,
+        max=1.0,
+        callback=_validate_threshold,
+    ),
+    ```
+  - Pass `confidence_threshold` to `run_review()` call
+  - **FR reference**: FR-003, FR-008, FR-012, FR-013
+  - **File paths**: `src/openreview_cli/app.py`
+  - **Dependencies**: T016, T019 (threshold propagation)
+  - **Complexity**: M
+
+- [ ] **T018** Write integration tests for threshold propagation in `tests/integration/test_three_color_pipeline.py`:
+  - Default threshold (0.7) produces expected color distribution
+  - Custom threshold (0.9) produces MORE Amber flags than default
+  - Custom threshold (0.3) produces FEWER Amber flags than default (SC-001)
+  - Clause with confidence 0.85 and threshold 0.9 → Amber (confidence < threshold)
+  - Clause with confidence 0.5 and threshold 0.5 → NOT Amber from threshold alone (`confidence < threshold` → `0.5 < 0.5` is False)
+  - Empty assessment list: no error, graceful handling
+  - Backward compat: `is_amber` accessible before and after `assign_colors()`
+  - Benchmark: 1,000 assessments compute colors in <100 ms (SC-004)
+  - Use monkeypatch or seeded data (no actual LLM calls)
+  - **FR reference**: FR-003, FR-007, FR-012, FR-013, SC-001, SC-004
+  - **File paths**: `tests/integration/test_three_color_pipeline.py` (NEW)
+  - **Dependencies**: T017 (CLI flag), T013 (report rendering)
+  - **Complexity**: M
+
+- [ ] **T019** Wire `confidence_threshold` through the review pipeline in `src/openreview_cli/review/__init__.py`:
+  - Add `confidence_threshold: float = 0.7` parameter to `run_review()` signature
+  - Pass `confidence_threshold` to `_build_report()` — store it in `ReviewReport.confidence_threshold`
+  - Update docstring with the new parameter
+  - No need to modify extraction, QA, or grounding stages — threshold only affects output rendering
+  - **FR reference**: FR-007, FR-013
+  - **File paths**: `src/openreview_cli/review/__init__.py`
+  - **Dependencies**: T010 (ReviewReport.confidence_threshold field), T017 (CLI flag exists)
+  - **Complexity**: S
+
+**Checkpoint**: MVP complete. Users can adjust threshold and see instant color recalculations. Invalid values rejected.
+
+---
+
+## Phase 4: US4 — Edge Cases & Validation (P3)
+
+**Goal**: Boundary conditions are handled correctly: empty assessments, threshold values at extremes (0.0, 1.0), threshold at exact boundary (0.5), multiple amber triggers simultaneously. Pipeline integration completes with `ReviewReport` recording the threshold used.
+
+**Independent Test**: Run with `--confidence-threshold 0.0` → no Amber from threshold alone, only error/QA-disagree. Run with `--confidence-threshold 1.0` → every non-perfect assessment is Amber.
+
+- [ ] **T020** Write edge case tests extending `tests/unit/test_three_color_models.py`:
+  - `--confidence-threshold 0.0`: no clause is Amber from threshold alone; only error/QA-disagree/grounding triggers Amber (FR-004)
+  - `--confidence-threshold 1.0`: every clause with confidence < 1.0 is Amber; only perfect assessments (confidence=1.0, no triggers) pass
+  - Threshold exactly 0.5 with confidence 0.5: NOT Amber from threshold (0.5 < 0.5 is False) — boundary correctness
+  - Empty assessment list: `assign_colors()` returns gracefully with no error
+  - Single-clause assessment list: works without special-casing
+  - Assessment with ALL triggers simultaneously: status is Amber once (not triplicate), `amber_reasons` contains all 6 reasons
+  - Assessment with no `grounding_verdict` (None): grounding is NOT a trigger (FR-004)
+  - All Amber: all assessments show Amber, summary correctly shows `amber_count = N, green_count = 0, red_count = 0`
+  - All Green: all favorable/neutral + confidence >= threshold → all Green, `amber_count = 0`
+  - All Red: all unfavorable + confidence >= threshold → all Red, `amber_count = 0`
+  - Mixture: 5 Green, 3 Amber, 2 Red → correct counts
+  - Performance: 1,000 assessments in <100 ms (SC-004)
+  - Determinism: same input → same output across multiple calls (SC-005)
+  - **FR reference**: FR-001, FR-002, FR-004, FR-011, FR-003, SC-004, SC-005
+  - **File paths**: `tests/unit/test_three_color_models.py`
+  - **Dependencies**: T004 (assign_colors implemented)
+  - **Complexity**: M
+
+- [ ] **T021** Write integration test for `ReviewReport` confidence_threshold recording in `tests/integration/test_three_color_pipeline.py`:
+  - `run_review()` with `confidence_threshold=0.7` → report has `confidence_threshold == 0.7`
+  - `run_review()` with `confidence_threshold=0.3` → report has `confidence_threshold == 0.3`
+  - Default (no argument) → report has `confidence_threshold == 0.7`
+  - `schema_version` in report is `"1.1.0"` (minor bump, backward compat)
+  - Two different thresholds on same input produce different color distributions with no pipeline re-run
+  - **FR reference**: FR-007, FR-003, SC-001
+  - **File paths**: `tests/integration/test_three_color_pipeline.py`
+  - **Dependencies**: T019 (threshold wired), T018 (integration test infra)
+  - **Complexity**: S
+
+- [ ] **T022** Ensure `ReviewReport` construction records `confidence_threshold` in `src/openreview_cli/review/__init__.py`:
+  - `_build_report()` already receives `confidence_threshold` from T019
+  - Pass it to `ReviewReport(..., confidence_threshold=confidence_threshold)`
+  - Update `_build_report()` to compute `green_count`, `red_count`, `avg_effective_confidence` in `ReviewSummary` — these are computed from assessments after color assignment
+  - Note: `_build_report()` currently computes `amber_count` from `a.is_amber` — this still works because `is_amber` is a property that works before and after `assign_colors()`
+  - The color counts in `ReviewSummary` are computed by `assign_colors()` before rendering, not in `_build_report()`. The fields default to 0 and get populated during rendering.
+  - Alternatively: compute summary counts in `_build_report()` by calling `assign_colors()` there too. But that would break FR-001 (color at output time only). Better: keep summary counts as 0 defaults, compute during rendering alongside color.
+  - **Resolution**: Keep `green_count`/`red_count`/`avg_effective_confidence` as 0 defaults. They are populated by `assign_colors()` or during rendering. The `amber_count` remains computed in `_build_report()` for backward compat.
+  - **FR reference**: FR-007, FR-003
+  - **File paths**: `src/openreview_cli/review/__init__.py`
+  - **Dependencies**: T021, T019 (threshold wired), T010 (fields exist)
+  - **Complexity**: S
+
+**Checkpoint**: All edge cases handled. Pipeline fully integrated with threshold recording.
+
+---
+
+## Phase 5: Polish & Cross-Cutting
+
+**Purpose**: Final integration, validation, and quality checks.
+
+- [ ] **T023** Run full test suite:
+  - `uv run pytest` — all unit and integration tests pass
+  - New tests pass: `tests/unit/test_three_color_models.py`, `tests/unit/test_three_color_report.py`, `tests/unit/test_three_color_cli.py`
+  - Extended tests pass: `tests/unit/test_review_models.py` (no regressions)
+  - Integration tests pass: `tests/integration/test_three_color_pipeline.py`
+  - Memory tests pass: `uv run pytest -m memory`
+  - Fix any regressions in existing tests from model changes (`is_amber` property, new fields)
+  - **FR reference**: All
+  - **Dependencies**: T022 (all implementation done)
+  - **Complexity**: M
+
+- [ ] **T024** Run lint and format:
+  - `uv run ruff check .` — zero new violations
+  - `uv run ruff format --check .` — zero formatting diffs
+  - Fix any lint/format issues in new or modified files
+  - **FR reference**: All
+  - **Dependencies**: T023
+  - **Complexity**: S
+
+- [ ] **T025** Run type check:
+  - `uv run mypy src/ tests/` — zero new typing errors
+  - No `# type: ignore` for three-color module code
+  - `AssessmentColor` and `AmberReason` correctly typed as StrEnum subclasses
+  - `assign_colors()` signature correctly typed
+  - `confidence_threshold` typed as `float` everywhere
+  - TYPE_CHECKING guards for cross-module imports (models.py → colors.py)
+  - **FR reference**: All
+  - **Dependencies**: T024
+  - **Complexity**: S
+
+- [ ] **T026** Run pre-commit:
+  - `uv run pre-commit run --all-files` — all hooks pass
+  - `ruff --fix` — no issues
+  - `ruff-format` — no reformatting
+  - `mypy` — clean
+  - `pytest-fast` — fast tests pass (no slow/integration tests in fast suite)
+  - stdlib hygiene — no issues
+  - **FR reference**: All
+  - **Dependencies**: T025
+  - **Complexity**: S
+
+- [ ] **T027** Quickstart validation scenarios from `specs/013-three-color-confidence/quickstart.md`:
+  - Scenario 1 — Default threshold: terminal shows three-color badges with correct Green/Amber/Red
+  - Scenario 2 — Custom threshold: `0.9` produces more Amber than `0.3`
+  - Scenario 3 — JSON output: all new fields present
+  - Scenario 4 — All Green edge case
+  - Scenario 5 — Low confidence Amber edge case with reason
+  - Scenario 6 — Backward compat: `is_amber` and `amber_count` still work
+  - Scenario 7 — Help text: `--help` includes accuracy ceiling disclosure
+  - Quick verification commands from quickstart.md all pass
+  - **FR reference**: All, SC-001 through SC-007
+  - **Dependencies**: T026 (pre-commit clean)
+  - **Complexity**: M
+
+---
+
+## Phase 6: Documentation
+
+- [ ] **T028** Update `AGENTS.md` deferred work table if any tasks are unblocked:
+  - Check the deferred table in AGENTS.md (Phase 3 PII Stripping deferred tasks)
+  - T033 (integration test for `--no-pii` flag) — blocked by review command existing (already exists as `precheck review`). The `--no-pii` flag is already on the `precheck review` command in `app.py`, so T033 test can be populated.
+  - T035 (add `--no-pii` flag to review commands) — already done (line 443 of app.py)
+  - **If T033 or T035 are now unblocked**, update the status and add a note referencing which task in this spec completed the unblocking
+  - Otherwise, note that no Phase 3 deferred tasks were unblocked
+  - **FR reference**: N/A (documentation)
+  - **File paths**: `AGENTS.md` (or report the finding)
+  - **Dependencies**: T027 (all scenarios validated)
+  - **Complexity**: S
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Foundational) — BLOCKS all user stories
+    ├── Phase 2 (US1+US3 — Three-Color Output) ← MVP
+    │       └── Phase 3 (US2 — Configurable Threshold) ← MVP+
+    │               └── Phase 4 (US4 — Edge Cases)
+    └── Phase 5 (Polish) — depends on all phases
+            └── Phase 6 (Documentation) — final
+```
+
+- **Phase 1** (Foundational): No dependencies — can start immediately. Blocking prerequisite for ALL phases.
+- **Phase 2** (US1+US3): Depends on Phase 1 complete. Core three-color display.
+- **Phase 3** (US2): Depends on Phase 2 (needs assign_colors to test threshold effect). Adds CLI flag.
+- **Phase 4** (US4): Depends on Phase 3 (needs threshold wiring for edge case tests).
+- **Phase 5** (Polish): Depends on all implementation phases (T022).
+- **Phase 6** (Documentation): Depends on Polish complete.
+
+### Within Each Phase
+
+- Tests (marked TDD) MUST be written and FAIL before implementation
+- Data models before services
+- Core implementation before integration
+- Phase complete before moving to next
+
+### Parallel Opportunities
+
+- **Phase 1 tasks**: T001 (enum tests), T003 (assign_color tests), T005 (eff_confidence tests), T007 (model extension tests), T009 (summary tests) — all test files can be drafted in parallel since they test different concerns. However, implementation (T002, T004, T006, T008, T010) must follow in dependency order.
+- **T012 and T014** (terminal + JSON output tests): Can be written in parallel.
+- **T013 and T015** (terminal + JSON implementation): Sequential (report.py same file).
+- **T016 and T018** (CLI unit tests + integration tests): Can be written in parallel.
+- **T020 and T021** (edge case unit tests + integration tests): Can be written in parallel.
+- **T023–T027** (Polish): Sequential — each fix cycle depends on previous.
+
+### Parallel Execution Example (Phase 1 — test files)
+
+```bash
+# Write all Phase 1 test files in parallel:
+Task: "Write enum tests"                     # T001
+Task: "Write assign_color tests"             # T003
+Task: "Write effective_confidence tests"     # T005
+Task: "Write ClauseAssessment extension tests"  # T007
+Task: "Write ReviewSummary extension tests"  # T009
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope (Phase 1 → Phase 2 → Phase 3)
+
+The MVP delivers US1 + US2 + US3 (both P1 and P2), providing:
+- Three-color terminal and JSON output (US1, P1)
+- Configurable `--confidence-threshold` CLI flag (US2, P1)
+- Amber reason breakdown in output (US3, P2)
+- Default threshold of 0.7 with accuracy ceiling disclosure
+
+**MVP ship**: Phase 3 (T019) complete. Both P1 features + P2 amber detail are working.
+
+### Full Delivery (MVP + Polish)
+
+1. Complete Phase 1: Foundational — Data Models & Color Logic
+2. Complete Phase 2: US1+US3 — Three-Color Output → Ship MVP candidate
+3. Complete Phase 3: US2 — Configurable Threshold → Ship MVP
+4. Complete Phase 4: US4 — Edge Cases & Validation
+5. Complete Phase 5: Polish — Quality gates
+6. Complete Phase 6: Documentation
+
+---
+
+## Summary
+
+| Item | Count |
+|------|-------|
+| **Total tasks** | 28 |
+| Phase 1 (Foundational) | 11 |
+| Phase 2 (US1+US3 — P1+P2 MVP) | 4 |
+| Phase 3 (US2 — P1) | 4 |
+| Phase 4 (US4 — P3) | 3 |
+| Phase 5 (Polish) | 5 |
+| Phase 6 (Documentation) | 1 |
+| New source files | 1 (`colors.py`) |
+| Modified source files | 4 (`models.py`, `report.py`, `__init__.py`, `app.py`) |
+| New test files | 4 (`test_three_color_models.py`, `test_three_color_report.py`, `test_three_color_cli.py`, `test_three_color_pipeline.py`) |
+| Extended test files | 1 (`test_review_models.py`) |
+
+### MVP scope (Phase 1-3, 19 tasks)
+
+The MVP includes three-color output, amber reason breakdown, and configurable threshold. This is shippable as a standalone feature — edge case validation (US4) is additive.
+
+### File creation/modification order
+
+1. `src/openreview_cli/review/colors.py` (NEW) + `tests/unit/test_three_color_models.py`
+2. `src/openreview_cli/review/models.py` (MODIFY)
+3. `src/openreview_cli/review/__init__.py` (MODIFY)
+4. `tests/unit/test_review_models.py` (EXTEND)
+5. `src/openreview_cli/review/report.py` (MODIFY) + `tests/unit/test_three_color_report.py`
+6. `src/openreview_cli/app.py` (MODIFY) + `tests/unit/test_three_color_cli.py`
+7. `tests/integration/test_three_color_pipeline.py` (NEW)

--- a/src/openreview_cli/app.py
+++ b/src/openreview_cli/app.py
@@ -20,6 +20,8 @@ from openreview_cli.storage.database import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CONFIDENCE_THRESHOLD: float = 0.7
+
 app = typer.Typer(
     name="openreview",
     help="Privacy-first contract review tool.",
@@ -33,6 +35,12 @@ def _version_callback(value: bool) -> None:
         _init()
         typer.echo(f"openreview {__version__}")
         raise typer.Exit()
+
+
+def _validate_threshold(value: float) -> float:
+    if not 0.0 <= value <= 1.0:
+        raise typer.BadParameter(f"confidence-threshold must be between 0.0 and 1.0, got {value}")
+    return value
 
 
 def _init(debug: bool = False) -> None:
@@ -450,6 +458,18 @@ def review(
     no_grounding: bool = typer.Option(
         False, "--no-grounding", help="Skip citation grounding entirely."
     ),
+    confidence_threshold: float = typer.Option(
+        DEFAULT_CONFIDENCE_THRESHOLD,
+        "--confidence-threshold",
+        "-ct",
+        help="Confidence threshold for Green/Amber/Red assignment (0.0-1.0). "
+        "Clauses with effective confidence below this threshold are marked Amber. "
+        "Note: The comparison accuracy of automated review is bounded by "
+        "approximately 64% F1. Three-color output (Green/Amber/Red) is "
+        "designed to mitigate this — set the threshold generously to push "
+        "uncertain comparisons to Amber rather than risking false Green or Red.",
+        callback=_validate_threshold,
+    ),
 ) -> None:
     """Review one or more contract documents against a 3-position playbook.
 
@@ -476,6 +496,7 @@ def review(
             no_pii=no_pii,
             verbose=verbose,
             grounding_mode=None if no_grounding else grounding_mode,
+            confidence_threshold=confidence_threshold,
         )
     except FileNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/openreview_cli/review/__init__.py
+++ b/src/openreview_cli/review/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 from openreview_cli.review.base import ReviewCommand
+from openreview_cli.review.colors import AmberReason, AssessmentColor, assign_colors
 from openreview_cli.review.extraction import extract_clause, match_category
 from openreview_cli.review.models import (
     ClauseAssessment,
@@ -36,8 +37,11 @@ from openreview_cli.review.report import format_json, format_terminal
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "AmberReason",
+    "AssessmentColor",
     "ReviewCommand",
     "ReviewReport",
+    "assign_colors",
     "format_json",
     "format_terminal",
     "run_review",
@@ -52,6 +56,7 @@ def run_review(
     no_pii: bool = False,
     verbose: bool = False,
     grounding_mode: str | None = None,
+    confidence_threshold: float = 0.7,
 ) -> list[ReviewReport]:
     """Run the PAKTON 3-agent review pipeline on one or more documents.
 
@@ -73,6 +78,8 @@ def run_review(
         Print per-clause progress to stderr when ``True``.
     grounding_mode : str | None
         Grounding mode: ``"strict"``, ``"lenient"``, or ``None`` to skip.
+    confidence_threshold : float
+        Threshold for Green/Amber/Red assignment (0.0-1.0). Default 0.7.
 
     Returns
     -------
@@ -140,7 +147,9 @@ def run_review(
             pii_stripped=False,
             parsed_at=datetime.now(UTC),
         )
-        report = _build_report(doc_meta, assessments, playbook)
+        report = _build_report(
+            doc_meta, assessments, playbook, confidence_threshold=confidence_threshold
+        )
 
         # Phase 5: Comparison — no-op for single-party review
 
@@ -189,14 +198,25 @@ def _build_report(
     doc_meta: DocMeta,
     assessments: list[ClauseAssessment],
     playbook: Playbook,
+    confidence_threshold: float = 0.7,
 ) -> ReviewReport:
     """Build a ReviewReport from assessments."""
+    assign_colors(assessments, confidence_threshold)
+
     total_conf = sum(a.confidence for a in assessments if a.playbook_category != "no-match")
     n_conf = sum(1 for a in assessments if a.playbook_category != "no-match") or 1
 
     pos_counts = Counter(a.position for a in assessments)
     no_match_count = sum(1 for a in assessments if a.playbook_category == "no-match")
-    amber_count = sum(1 for a in assessments if a.is_amber)
+    green_count = sum(1 for a in assessments if a.color == AssessmentColor.green)
+    red_count = sum(1 for a in assessments if a.color == AssessmentColor.red)
+    amber_count = sum(1 for a in assessments if a.color == AssessmentColor.amber)
+    valid_conf = [
+        a.effective_confidence
+        for a in assessments
+        if a.effective_confidence is not None and a.playbook_category != "no-match"
+    ]
+    avg_effective_confidence = sum(valid_conf) / len(valid_conf) if valid_conf else 0.0
 
     summary = ReviewSummary(
         favorable_count=pos_counts.get(Position.favorable, 0),
@@ -204,8 +224,11 @@ def _build_report(
         unfavorable_count=pos_counts.get(Position.unfavorable, 0),
         uncertain_count=pos_counts.get(Position.uncertain, 0),
         no_match_count=no_match_count,
+        green_count=green_count,
+        red_count=red_count,
         amber_count=amber_count,
         avg_confidence=total_conf / n_conf,
+        avg_effective_confidence=avg_effective_confidence,
     )
 
     return ReviewReport(
@@ -214,4 +237,5 @@ def _build_report(
         summary=summary,
         playbook_id=playbook.id,
         generated_at=datetime.now(UTC),
+        confidence_threshold=confidence_threshold,
     )

--- a/src/openreview_cli/review/colors.py
+++ b/src/openreview_cli/review/colors.py
@@ -1,0 +1,77 @@
+"""Three-color output with confidence scores."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openreview_cli.review.models import ClauseAssessment
+
+
+class AssessmentColor(StrEnum):
+    green = "green"
+    amber = "amber"
+    red = "red"
+
+
+class AmberReason(StrEnum):
+    low_confidence = "low_confidence"
+    qa_disagreement = "qa_disagreement"
+    qa_uncertain = "qa_uncertain"
+    error = "error"
+    grounding_failure = "grounding_failure"
+    grounding_uncertain = "grounding_uncertain"
+
+
+def effective_confidence(
+    extraction_confidence: float | None = None,
+    qa_confidence: float | None = None,
+    grounding_confidence: float | None = None,
+) -> float:
+    return min(
+        extraction_confidence if extraction_confidence is not None else 1.0,
+        qa_confidence if qa_confidence is not None else 1.0,
+        grounding_confidence if grounding_confidence is not None else 1.0,
+    )
+
+
+def _collect_triggers(a: Any, eff_conf: float, threshold: float) -> list[AmberReason]:
+    triggers: list[AmberReason] = []
+    if a.error is not None:
+        triggers.append(AmberReason.error)
+    if eff_conf < threshold:
+        triggers.append(AmberReason.low_confidence)
+    if a.qa_verdict == "disagree":
+        triggers.append(AmberReason.qa_disagreement)
+    if a.qa_verdict == "uncertain":
+        triggers.append(AmberReason.qa_uncertain)
+    if a.grounding_verdict is not None:
+        if a.grounding_verdict == "ungrounded":
+            triggers.append(AmberReason.grounding_failure)
+        if a.grounding_verdict == "uncertain":
+            triggers.append(AmberReason.grounding_uncertain)
+    return triggers
+
+
+def assign_colors(assessments: list[ClauseAssessment], threshold: float = 0.7) -> None:
+    for a in assessments:
+        eff_conf = effective_confidence(
+            extraction_confidence=a.confidence,
+            grounding_confidence=a.grounding_confidence,
+        )
+        triggers = _collect_triggers(a, eff_conf, threshold)
+
+        if triggers:
+            color = AssessmentColor.amber
+        elif a.position == "unfavorable" and eff_conf >= threshold:
+            color = AssessmentColor.red
+        elif a.position in ("favorable", "neutral") and eff_conf >= threshold:
+            color = AssessmentColor.green
+        else:
+            color = AssessmentColor.amber
+
+        a.color = color
+        a.effective_confidence = eff_conf
+        a.amber_reasons = triggers
+        a.is_amber = color == AssessmentColor.amber

--- a/src/openreview_cli/review/models.py
+++ b/src/openreview_cli/review/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
         CitationProvenance,
         GroundingVerdict,
     )
+    from openreview_cli.review.colors import AmberReason, AssessmentColor
 
 
 class Position(StrEnum):
@@ -103,7 +104,12 @@ class ClauseAssessment:
     qa_revised_position: Position | None = None
     qa_revised_rationale: str | None = None
     error: str | None = None
-    is_amber: bool = False
+    # Three-color fields (set by assign_colors(), default None)
+    color: AssessmentColor | None = None
+    amber_reasons: list[AmberReason] | None = None
+    effective_confidence: float | None = None
+    # Backward-compat amber indicator (set by assign_colors() and accessible via @property)
+    _is_amber: bool = field(default=False, repr=False)
     # Citation grounding discriminator fields (all optional, default None)
     grounding_verdict: GroundingVerdict | None = None
     grounding_provenances: list[CitationProvenance] | None = None
@@ -112,13 +118,17 @@ class ClauseAssessment:
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence <= 1.0:
             raise ValueError("confidence must be in range 0.0-1.0")
-        # Auto-set is_amber based on rules
-        if (
-            self.error is not None
-            or self.confidence < 0.5
-            or self.qa_verdict in (QAVerdict.disagree, QAVerdict.uncertain)
-        ):
-            self.is_amber = True
+
+    @property
+    def is_amber(self) -> bool:
+        """Return True if the clause is amber, based on color (if assigned) or stored value."""
+        if self.color is not None:
+            return str(self.color) == "amber"
+        return self._is_amber
+
+    @is_amber.setter
+    def is_amber(self, value: bool) -> None:
+        self._is_amber = value
 
 
 @dataclass
@@ -142,7 +152,10 @@ class ReviewSummary:
     uncertain_count: int = 0
     no_match_count: int = 0
     amber_count: int = 0
+    green_count: int = 0
+    red_count: int = 0
     avg_confidence: float = 0.0
+    avg_effective_confidence: float = 0.0
 
     @property
     def total(self) -> int:
@@ -164,4 +177,5 @@ class ReviewReport:
     summary: ReviewSummary
     playbook_id: str
     generated_at: datetime
-    schema_version: str = "1.0.0"
+    confidence_threshold: float = 0.7
+    schema_version: str = "1.1.0"

--- a/src/openreview_cli/review/report.py
+++ b/src/openreview_cli/review/report.py
@@ -10,10 +10,11 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+from openreview_cli.review.colors import AssessmentColor
 from openreview_cli.review.models import Position, ReviewReport
 
 
-def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: function extraction would add more complexity
+def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0912, PLR0915  # ponytail: function extraction would add more complexity
     """Format a ``ReviewReport`` as a human-readable terminal string.
 
     Produces a Rich-styled table with per-clause position badges, confidence
@@ -21,6 +22,11 @@ def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: 
 
     Returns the rendered string (no side effects).
     """
+    # ponytail: safety net — ensure colors are assigned for directly-constructed reports
+    if report.assessments and report.assessments[0].color is None:
+        from openreview_cli.review.colors import assign_colors
+
+        assign_colors(report.assessments, threshold=report.confidence_threshold)
     from rich.console import Console
     from rich.table import Table
 
@@ -59,7 +65,7 @@ def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: 
     table.add_column("Confidence", width=12)
     if has_grounding:
         table.add_column("Gnd", width=6)
-    table.add_column("Status", width=8)
+    table.add_column("Status", width=10)
 
     for i, ca in enumerate(report.assessments, 1):
         clause_display = ca.clause_text[:80].replace("\n", " ")
@@ -68,10 +74,16 @@ def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: 
 
         pos_text = _position_style(ca)
         conf_bar = _confidence_bar(ca.confidence)
-        status = "[bold red]⚠ AMBER[/bold red]" if ca.is_amber else "[dim]OK[/dim]"
         category_display = (
             ca.playbook_category.replace("-", " ").title() if ca.playbook_category else "—"
         )
+
+        if ca.color == AssessmentColor.green:
+            status = "[green]● OK[/green]"
+        elif ca.color == AssessmentColor.red:
+            status = "[bold red]● RED[/bold red]"
+        else:
+            status = "[bold yellow]⚠ AMBER[/bold yellow]"
 
         row: list[str] = [str(i), clause_display, category_display, pos_text, conf_bar]
         if has_grounding:
@@ -82,9 +94,31 @@ def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: 
     console.print(table)
     console.print()
 
+    # Amber reason details
+    amber_details = [
+        (idx, ca)
+        for idx, ca in enumerate(report.assessments, 1)
+        if ca.color == AssessmentColor.amber and ca.amber_reasons
+    ]
+    if amber_details:
+        console.print("[bold]Amber Details[/bold]")
+        for a_idx, ca in amber_details:
+            reasons = ca.amber_reasons or []
+            reason_strs: list[str] = []
+            for r in reasons:
+                if r == "low_confidence" and ca.effective_confidence is not None:
+                    reason_strs.append(f"Low confidence ({ca.effective_confidence:.2f})")
+                else:
+                    reason_strs.append(str(r).replace("_", " ").title())
+            console.print(f"  #{a_idx}: {', '.join(reason_strs)}")
+        console.print()
+
     # Summary
     summary = report.summary
     console.print("[bold]Summary[/bold]")
+    console.print(f"  Green:       {summary.green_count}")
+    console.print(f"  Amber:       {summary.amber_count}")
+    console.print(f"  Red:         {summary.red_count}")
     console.print(f"  Favorable:   {summary.favorable_count}")
     console.print(f"  Neutral:     {summary.neutral_count}")
     console.print(f"  Unfavorable: {summary.unfavorable_count}")
@@ -97,6 +131,8 @@ def format_terminal(report: ReviewReport) -> str:  # noqa: PLR0915  # ponytail: 
         if summary.avg_confidence
         else "  Avg confidence: —"
     )
+    console.print(f"  Avg effective confidence: {summary.avg_effective_confidence:.2f}")
+    console.print(f"  Confidence threshold: {report.confidence_threshold}")
     if has_grounding:
         _print_grounding_summary(report, console)
     console.print()
@@ -175,8 +211,18 @@ def format_json(reports: ReviewReport | Sequence[ReviewReport]) -> str:
         JSON string with indentation.
     """
     if isinstance(reports, ReviewReport):
+        # ponytail: safety net — ensure colors are assigned for directly-constructed reports
+        if reports.assessments and reports.assessments[0].color is None:
+            from openreview_cli.review.colors import assign_colors
+
+            assign_colors(reports.assessments, threshold=reports.confidence_threshold)
         data: dict[str, Any] | list[dict[str, Any]] = _report_to_dict(reports)
     else:
+        for r in reports:
+            if r.assessments and r.assessments[0].color is None:
+                from openreview_cli.review.colors import assign_colors
+
+                assign_colors(r.assessments, threshold=r.confidence_threshold)
         data = [_report_to_dict(r) for r in reports]
     return json.dumps(data, indent=2, default=str, ensure_ascii=False)
 
@@ -186,5 +232,13 @@ def _report_to_dict(report: ReviewReport) -> dict[str, Any]:
 
     ``asdict`` handles nested dataclasses recursively. ``json.dumps(default=str)``
     in ``format_json`` handles ``datetime`` and ``StrEnum`` serialisation.
+
+    ``is_amber`` is a ``@property`` on ``ClauseAssessment`` (not a dataclass field),
+    so it is not included by ``asdict`` — we add it manually from the live objects.
     """
-    return dataclasses.asdict(report)
+    data = dataclasses.asdict(report)
+    # Restore is_amber from the @property (asdict uses _is_amber field instead)
+    for assessment, a_dict in zip(report.assessments, data.get("assessments", []), strict=True):
+        a_dict.pop("_is_amber", None)
+        a_dict["is_amber"] = assessment.is_amber
+    return data

--- a/tests/integration/test_precheck_review.py
+++ b/tests/integration/test_precheck_review.py
@@ -249,7 +249,7 @@ class TestJsonSchema:
         data = _report_to_dict(report)
 
         # Validate structure
-        assert data["schema_version"] == "1.0.0"
+        assert data["schema_version"] == "1.1.0"
         assert data["document"]["filename"] == "test.docx"
         assert len(data["assessments"]) == 1
         assert data["assessments"][0]["position"] == "favorable"
@@ -260,4 +260,4 @@ class TestJsonSchema:
         # Test serialization
         json_str = json.dumps(data, default=str)
         parsed = json.loads(json_str)
-        assert parsed["schema_version"] == "1.0.0"
+        assert parsed["schema_version"] == "1.1.0"

--- a/tests/integration/test_three_color_pipeline.py
+++ b/tests/integration/test_three_color_pipeline.py
@@ -1,0 +1,249 @@
+"""Integration tests for three-color pipeline integration with confidence_threshold."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from openreview_cli.grounding.models import GroundingVerdict
+from openreview_cli.review.colors import AmberReason, AssessmentColor, assign_colors
+from openreview_cli.review.models import (
+    ClauseAssessment,
+    DocMeta,
+    Position,
+    QAVerdict,
+    ReviewReport,
+    ReviewSummary,
+)
+
+
+def _make_assessment(
+    cid: str,
+    pos: Position,
+    conf: float,
+    qa_verdict: QAVerdict = QAVerdict.agree,
+    error: str | None = None,
+    grounding_verdict: GroundingVerdict | None = None,
+) -> ClauseAssessment:
+    return ClauseAssessment(
+        clause_id=cid,
+        clause_text=f"Clause {cid} text.",
+        playbook_category="confidentiality-term",
+        position=pos,
+        confidence=conf,
+        citation=f"citation {cid}",
+        qa_verdict=qa_verdict,
+        extraction_model="m1",
+        qa_model="m1",
+        error=error,
+        grounding_verdict=grounding_verdict,
+    )
+
+
+def _make_report(
+    assessments: list[ClauseAssessment],
+    threshold: float = 0.7,
+) -> ReviewReport:
+    dm = DocMeta(
+        filename="test.pdf",
+        page_count=5,
+        clause_count=len(assessments),
+        pii_stripped=False,
+    )
+    summary = ReviewSummary(
+        favorable_count=sum(1 for a in assessments if a.position == Position.favorable),
+        neutral_count=sum(1 for a in assessments if a.position == Position.neutral),
+        unfavorable_count=sum(1 for a in assessments if a.position == Position.unfavorable),
+        uncertain_count=sum(1 for a in assessments if a.position == Position.uncertain),
+        no_match_count=0,
+        amber_count=sum(1 for a in assessments if a.is_amber),
+        avg_confidence=sum(a.confidence for a in assessments) / max(len(assessments), 1),
+    )
+    return ReviewReport(
+        document=dm,
+        assessments=assessments,
+        summary=summary,
+        playbook_id="precheck-nda-v1",
+        generated_at=datetime.now(UTC),
+        confidence_threshold=threshold,
+    )
+
+
+class TestThresholdPropagation:
+    def test_default_threshold_colors(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        assert assessments[0].color == AssessmentColor.green
+        assert assessments[1].color == AssessmentColor.amber
+
+    def test_custom_threshold_more_amber(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.85),
+            _make_assessment("c2", Position.neutral, 0.72),
+        ]
+        # 0.7 threshold: both >= 0.7 → both green
+        assign_colors(assessments, threshold=0.7)
+        assert assessments[0].color == AssessmentColor.green
+        assert assessments[1].color == AssessmentColor.green
+
+        # Reset and apply 0.9 threshold: 0.85 < 0.9 → amber
+        for a in assessments:
+            a.color = None
+            a.amber_reasons = None
+            a.effective_confidence = None
+        assign_colors(assessments, threshold=0.9)
+        assert assessments[0].color == AssessmentColor.amber  # type: ignore[comparison-overlap]
+        assert assessments[1].color == AssessmentColor.amber
+
+    def test_custom_threshold_fewer_amber(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.3),
+            _make_assessment("c2", Position.neutral, 0.45),
+        ]
+        # 0.7 threshold: both < 0.7 → both amber
+        assign_colors(assessments, threshold=0.7)
+        assert assessments[0].color == AssessmentColor.amber
+        assert assessments[1].color == AssessmentColor.amber
+
+        # Reset and apply 0.3 threshold: 0.3 < 0.3 is False → only 0.45 stays amber from low_confidence
+        for a in assessments:
+            a.color = None
+            a.amber_reasons = None
+            a.effective_confidence = None
+        assign_colors(assessments, threshold=0.3)
+        # 0.3 is NOT < 0.3, so c1 is not amber from threshold alone
+        # But c1 position is favorable and conf >= threshold, so green
+        assert assessments[0].color == AssessmentColor.green  # type: ignore[comparison-overlap]
+        # 0.45 < 0.3 is False, so c2 is also not amber from threshold
+        # position neutral, conf >= threshold, so green
+        assert assessments[1].color == AssessmentColor.green
+
+    def test_ninety_threshold_on_eighty_five(self) -> None:
+        """Clause with confidence 0.85 and threshold 0.9 → Amber."""
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.85),
+        ]
+        assign_colors(assessments, threshold=0.9)
+        assert assessments[0].color == AssessmentColor.amber
+        assert AmberReason.low_confidence in assessments[0].amber_reasons  # type: ignore[operator]
+
+    def test_threshold_at_boundary(self) -> None:
+        """Clause with confidence 0.5 and threshold 0.5 → NOT Amber from threshold."""
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.5),
+        ]
+        assign_colors(assessments, threshold=0.5)
+        # 0.5 < 0.5 is False, so no low_confidence trigger
+        # Position favorable, conf >= threshold → Green
+        assert assessments[0].color == AssessmentColor.green
+
+    def test_empty_assessment_list(self) -> None:
+        assign_colors([], threshold=0.7)
+        # Should not raise
+
+    def test_report_records_confidence_threshold(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        report = _make_report(assessments, threshold=0.7)
+        assert report.confidence_threshold == 0.7
+
+    def test_report_records_custom_threshold(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        report = _make_report(assessments, threshold=0.3)
+        assert report.confidence_threshold == 0.3
+
+    def test_report_default_threshold(self) -> None:
+        report = _make_report([])
+        assert report.confidence_threshold == 0.7
+
+    def test_schema_version_is_1_1_0(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        report = _make_report(assessments)
+        assert report.schema_version == "1.1.0"
+
+    def test_summary_green_red_counts_after_colors(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.unfavorable, 0.85),
+            _make_assessment("c3", Position.favorable, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        green_count = sum(1 for a in report.assessments if a.color == AssessmentColor.green)
+        red_count = sum(1 for a in report.assessments if a.color == AssessmentColor.red)
+        assert green_count == 1
+        assert red_count == 1
+        assert len(assessments) - green_count - red_count == 1  # amber
+
+    def test_avg_effective_confidence_calculated(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.85),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        vals = [a.effective_confidence for a in assessments if a.effective_confidence is not None]
+        avg = sum(vals) / len(vals) if vals else 0.0
+        assert avg == 0.885
+
+    def test_backward_compat_is_amber_accessible(self) -> None:
+        """is_amber should be accessible after assign_colors."""
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.favorable, 0.45),
+        ]
+        # Before assign_colors, is_amber returns _is_amber (default False)
+        assert assessments[0].is_amber is False
+        assert assessments[1].is_amber is False
+
+        assign_colors(assessments, threshold=0.7)
+        # After assign_colors, is_amber reflects the assigned color
+        assert assessments[0].is_amber is False  # green
+        assert assessments[1].is_amber is True  # amber
+        assert assessments[0].color == AssessmentColor.green
+        assert assessments[1].color == AssessmentColor.amber
+
+
+class TestPerformanceAndDeterminism:
+    def test_thousand_assessments_under_100ms(self) -> None:
+        import time
+
+        assessments = [
+            _make_assessment(
+                str(i),
+                Position.favorable
+                if i % 3 == 0
+                else Position.unfavorable
+                if i % 3 == 1
+                else Position.neutral,
+                0.3 + (i % 7) * 0.1,
+                grounding_verdict=GroundingVerdict.UNGROUNDED if i % 5 == 0 else None,
+            )
+            for i in range(1000)
+        ]
+        start = time.perf_counter()
+        assign_colors(assessments, threshold=0.7)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 0.1, f"assign_colors took {elapsed:.3f}s, expected <0.1s"
+
+    def test_deterministic_output(self) -> None:
+        assessments1 = [
+            _make_assessment("c1", Position.favorable, 0.6),
+            _make_assessment("c2", Position.unfavorable, 0.9),
+        ]
+        assessments2 = [
+            _make_assessment("c1", Position.favorable, 0.6),
+            _make_assessment("c2", Position.unfavorable, 0.9),
+        ]
+        assign_colors(assessments1, threshold=0.7)
+        assign_colors(assessments2, threshold=0.7)
+        for a1, a2 in zip(assessments1, assessments2, strict=True):
+            assert a1.color == a2.color
+            assert a1.effective_confidence == a2.effective_confidence
+            assert a1.amber_reasons == a2.amber_reasons

--- a/tests/unit/test_review_models.py
+++ b/tests/unit/test_review_models.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from openreview_cli.review.colors import assign_colors
 from openreview_cli.review.models import (
     Category,
     ClauseAssessment,
@@ -154,6 +155,7 @@ class TestClauseAssessment:
             extraction_model="m1",
             qa_model="m1",
         )
+        assign_colors([ca])
         assert ca.is_amber is True
 
     def test_qa_disagreement_triggers_amber(self) -> None:
@@ -170,6 +172,7 @@ class TestClauseAssessment:
             extraction_model="m1",
             qa_model="m1",
         )
+        assign_colors([ca])
         assert ca.is_amber is True
         assert ca.qa_revised_position == Position.neutral
 
@@ -186,6 +189,7 @@ class TestClauseAssessment:
             qa_model="m1",
             error="Model returned unparseable output",
         )
+        assign_colors([ca])
         assert ca.is_amber is True
 
     def test_confidence_range_validation(self) -> None:
@@ -214,6 +218,7 @@ class TestClauseAssessment:
             extraction_model="m1",
             qa_model="m1",
         )
+        assign_colors([ca])
         assert ca.is_amber is True
         assert ca.playbook_category == "no-match"
 
@@ -277,6 +282,6 @@ class TestReviewReport:
             playbook_id="precheck-nda-v1",
             generated_at=now,
         )
-        assert report.schema_version == "1.0.0"
+        assert report.schema_version == "1.1.0"
         assert len(report.assessments) == 2
         assert report.playbook_id == "precheck-nda-v1"

--- a/tests/unit/test_review_report.py
+++ b/tests/unit/test_review_report.py
@@ -17,7 +17,7 @@ from openreview_cli.review.report import format_json, format_terminal
 
 
 def _make_assessment(cid: str, pos: Position, conf: float, amber: bool = False) -> ClauseAssessment:
-    return ClauseAssessment(
+    ca = ClauseAssessment(
         clause_id=cid,
         clause_text=f"Clause {cid} text that is reasonably long enough to appear in reports.",
         playbook_category="confidentiality-term",
@@ -27,8 +27,10 @@ def _make_assessment(cid: str, pos: Position, conf: float, amber: bool = False) 
         qa_verdict=QAVerdict.agree,
         extraction_model="m1",
         qa_model="m1",
-        is_amber=amber,
     )
+    if amber:
+        ca.is_amber = True
+    return ca
 
 
 def _make_report(assessments: list[ClauseAssessment] | None = None) -> ReviewReport:
@@ -127,7 +129,7 @@ class TestFormatJson:
     def test_schema_version_present(self) -> None:
         report = _make_report()
         data = json.loads(format_json(report))
-        assert data["schema_version"] == "1.0.0"
+        assert data["schema_version"] == "1.1.0"
 
     def test_document_metadata_included(self) -> None:
         report = _make_report()

--- a/tests/unit/test_three_color_cli.py
+++ b/tests/unit/test_three_color_cli.py
@@ -1,0 +1,38 @@
+"""Unit tests for --confidence-threshold CLI flag and validation."""
+
+import inspect
+
+import pytest
+import typer
+
+from openreview_cli.app import DEFAULT_CONFIDENCE_THRESHOLD, _validate_threshold
+
+
+class TestHelpTextDisclosure:
+    def test_help_text_contains_accuracy_disclosure(self) -> None:
+        """Accuracy ceiling disclosure appears in help text."""
+        from openreview_cli.app import review
+
+        src = inspect.getsource(review)
+        assert "accuracy" in src.lower(), "help text should mention accuracy ceiling"
+
+
+class TestThresholdValidation:
+    def test_default_constant(self) -> None:
+        assert DEFAULT_CONFIDENCE_THRESHOLD == 0.7
+
+    def test_valid_values_accepted(self) -> None:
+        assert _validate_threshold(0.0) == 0.0
+        assert _validate_threshold(0.3) == 0.3
+        assert _validate_threshold(0.5) == 0.5
+        assert _validate_threshold(0.7) == 0.7
+        assert _validate_threshold(0.9) == 0.9
+        assert _validate_threshold(1.0) == 1.0
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(typer.BadParameter):
+            _validate_threshold(-0.1)
+
+    def test_above_one_rejected(self) -> None:
+        with pytest.raises(typer.BadParameter):
+            _validate_threshold(1.5)

--- a/tests/unit/test_three_color_models.py
+++ b/tests/unit/test_three_color_models.py
@@ -1,0 +1,377 @@
+"""Unit tests for three-color confidence models.
+
+Covers AssessmentColor/AmberReason enums, effective_confidence(),
+assign_colors(), and is_amber backward compat.
+"""
+
+from __future__ import annotations
+
+import time
+
+from openreview_cli.grounding.models import GroundingVerdict
+from openreview_cli.review.colors import (
+    AmberReason,
+    AssessmentColor,
+    assign_colors,
+    effective_confidence,
+)
+from openreview_cli.review.models import (
+    ClauseAssessment,
+    Position,
+    QAVerdict,
+    ReviewReport,
+    ReviewSummary,
+)
+
+
+class TestAssessmentColor:
+    def test_enum_values(self) -> None:
+        assert AssessmentColor.green.value == "green"
+        assert AssessmentColor.amber.value == "amber"
+        assert AssessmentColor.red.value == "red"
+
+    def test_str_enum(self) -> None:
+        assert str(AssessmentColor.green) == "green"
+        assert str(AssessmentColor.amber) == "amber"
+        assert str(AssessmentColor.red) == "red"
+
+    def test_json_serializable(self) -> None:
+        import json
+
+        assert json.dumps(AssessmentColor.green) == '"green"'
+
+
+class TestAmberReason:
+    def test_enum_values(self) -> None:
+        assert AmberReason.low_confidence.value == "low_confidence"
+        assert AmberReason.qa_disagreement.value == "qa_disagreement"
+        assert AmberReason.qa_uncertain.value == "qa_uncertain"
+        assert AmberReason.error.value == "error"
+        assert AmberReason.grounding_failure.value == "grounding_failure"
+        assert AmberReason.grounding_uncertain.value == "grounding_uncertain"
+
+    def test_str_enum(self) -> None:
+        assert str(AmberReason.low_confidence) == "low_confidence"
+        assert str(AmberReason.qa_disagreement) == "qa_disagreement"
+
+    def test_json_serializable(self) -> None:
+        import json
+
+        assert json.dumps(AmberReason.error) == '"error"'
+
+
+class TestEffectiveConfidence:
+    def test_all_stages_present(self) -> None:
+        assert (
+            effective_confidence(
+                extraction_confidence=0.8,
+                qa_confidence=0.9,
+                grounding_confidence=0.7,
+            )
+            == 0.7
+        )
+
+    def test_only_extraction(self) -> None:
+        assert effective_confidence(extraction_confidence=0.8) == 0.8
+
+    def test_extraction_none_grounding_0_7(self) -> None:
+        assert effective_confidence(extraction_confidence=None, grounding_confidence=0.7) == 0.7
+
+    def test_grounding_none_extraction_0_5(self) -> None:
+        assert effective_confidence(extraction_confidence=0.5, grounding_confidence=None) == 0.5
+
+    def test_all_none_defaults_to_one(self) -> None:
+        assert effective_confidence() == 1.0
+
+    def test_zero_confidence(self) -> None:
+        assert effective_confidence(extraction_confidence=0.0) == 0.0
+
+    def test_min_of_all_values(self) -> None:
+        assert (
+            effective_confidence(
+                extraction_confidence=0.9,
+                qa_confidence=0.5,
+                grounding_confidence=0.8,
+            )
+            == 0.5
+        )
+
+    def test_all_at_one(self) -> None:
+        assert (
+            effective_confidence(
+                extraction_confidence=1.0,
+                qa_confidence=1.0,
+                grounding_confidence=1.0,
+            )
+            == 1.0
+        )
+
+
+def _make_assessment(
+    confidence: float = 0.8,
+    position: Position = Position.favorable,
+    qa_verdict: QAVerdict = QAVerdict.agree,
+    error: str | None = None,
+    grounding_verdict: GroundingVerdict | None = None,
+    grounding_confidence: float | None = None,
+) -> ClauseAssessment:
+    return ClauseAssessment(
+        clause_id="c1",
+        clause_text="Some clause text.",
+        playbook_category="test",
+        position=position,
+        confidence=confidence,
+        citation="text",
+        qa_verdict=qa_verdict,
+        extraction_model="m1",
+        qa_model="m1",
+        error=error,
+        grounding_verdict=grounding_verdict,
+        grounding_confidence=grounding_confidence,
+    )
+
+
+class TestAssignColors:
+    def test_favorable_high_confidence_green(self) -> None:
+        a = _make_assessment(confidence=0.85, position=Position.favorable)
+        assign_colors([a])
+        assert a.color == AssessmentColor.green
+        assert a.effective_confidence == 0.85
+        assert a.amber_reasons == []
+
+    def test_neutral_high_confidence_green(self) -> None:
+        a = _make_assessment(confidence=0.85, position=Position.neutral)
+        assign_colors([a])
+        assert a.color == AssessmentColor.green
+
+    def test_unfavorable_high_confidence_red(self) -> None:
+        a = _make_assessment(confidence=0.85, position=Position.unfavorable)
+        assign_colors([a])
+        assert a.color == AssessmentColor.red
+        assert a.effective_confidence == 0.85
+        assert a.amber_reasons == []
+
+    def test_low_confidence_amber(self) -> None:
+        a = _make_assessment(confidence=0.4, position=Position.favorable)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.low_confidence in (a.amber_reasons or [])
+
+    def test_qa_disagreement_amber(self) -> None:
+        a = _make_assessment(qa_verdict=QAVerdict.disagree)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.qa_disagreement in (a.amber_reasons or [])
+
+    def test_qa_uncertain_amber(self) -> None:
+        a = _make_assessment(qa_verdict=QAVerdict.uncertain)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.qa_uncertain in (a.amber_reasons or [])
+
+    def test_error_amber(self) -> None:
+        a = _make_assessment(error="Model failed")
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.error in (a.amber_reasons or [])
+
+    def test_grounding_failure_amber(self) -> None:
+        a = _make_assessment(grounding_verdict=GroundingVerdict.UNGROUNDED)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.grounding_failure in (a.amber_reasons or [])
+
+    def test_grounding_uncertain_amber(self) -> None:
+        a = _make_assessment(grounding_verdict=GroundingVerdict.UNCERTAIN)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.grounding_uncertain in (a.amber_reasons or [])
+
+    def test_uncertain_position_amber(self) -> None:
+        a = _make_assessment(position=Position.uncertain)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+
+    def test_threshold_boundary_not_amber(self) -> None:
+        """Confidence exactly at threshold is NOT amber from threshold alone."""
+        a = _make_assessment(confidence=0.5, position=Position.favorable)
+        assign_colors([a], threshold=0.5)
+        assert a.color == AssessmentColor.green
+        assert AmberReason.low_confidence not in (a.amber_reasons or [])
+
+    def test_custom_threshold(self) -> None:
+        a = _make_assessment(confidence=0.75, position=Position.favorable)
+        assign_colors([a], threshold=0.9)
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.low_confidence in (a.amber_reasons or [])
+
+    def test_threshold_zero(self) -> None:
+        """threshold=0.0 → no clause goes amber from threshold alone (only from other triggers)."""
+        # High-confidence favorable — stays green
+        a1 = _make_assessment(confidence=0.92, position=Position.favorable)
+        # Low-confidence (0.1) but threshold=0.0 means no low_confidence trigger
+        a2 = _make_assessment(confidence=0.1, position=Position.favorable)
+        # Error — should still be amber regardless of threshold
+        a3 = _make_assessment(confidence=0.8, error="Failed", position=Position.favorable)
+        # QA disagree — should still be amber regardless of threshold
+        a4 = _make_assessment(
+            confidence=0.8, qa_verdict=QAVerdict.disagree, position=Position.favorable
+        )
+
+        assign_colors([a1, a2, a3, a4], threshold=0.0)
+        assert a1.color == AssessmentColor.green
+        # 0.1 < 0.0 is False, so no low_confidence trigger → green
+        assert a2.color == AssessmentColor.green
+        # Error trigger still fires → amber
+        assert a3.color == AssessmentColor.amber
+        assert AmberReason.error in (a3.amber_reasons or [])
+        # QA disagree trigger still fires → amber
+        assert a4.color == AssessmentColor.amber
+        assert AmberReason.qa_disagreement in (a4.amber_reasons or [])
+
+    def test_threshold_one(self) -> None:
+        """threshold=1.0 → every clause with confidence < 1.0 goes amber (unless other triggers beat it)."""
+        a1 = _make_assessment(confidence=0.99, position=Position.favorable)
+        a2 = _make_assessment(confidence=0.5, position=Position.favorable)
+        # unfavorable with conf < 1.0 — still amber because low_confidence, not red
+        a3 = _make_assessment(confidence=0.85, position=Position.unfavorable)
+
+        assign_colors([a1, a2, a3], threshold=1.0)
+        assert a1.color == AssessmentColor.amber
+        assert AmberReason.low_confidence in (a1.amber_reasons or [])
+        assert a2.color == AssessmentColor.amber
+        assert AmberReason.low_confidence in (a2.amber_reasons or [])
+        assert a3.color == AssessmentColor.amber
+        assert AmberReason.low_confidence in (a3.amber_reasons or [])
+
+    def test_empty_list(self) -> None:
+        assign_colors([])
+
+    def test_multiple_triggers(self) -> None:
+        a = _make_assessment(
+            confidence=0.3,
+            position=Position.unfavorable,
+            qa_verdict=QAVerdict.disagree,
+            error="Failed",
+            grounding_verdict=GroundingVerdict.UNGROUNDED,
+        )
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert AmberReason.error in (a.amber_reasons or [])
+        assert AmberReason.low_confidence in (a.amber_reasons or [])
+        assert AmberReason.qa_disagreement in (a.amber_reasons or [])
+        assert AmberReason.grounding_failure in (a.amber_reasons or [])
+
+    def test_no_grounding_data_no_grounding_trigger(self) -> None:
+        a = _make_assessment(
+            confidence=0.85,
+            position=Position.favorable,
+            grounding_verdict=None,
+            grounding_confidence=None,
+        )
+        assign_colors([a])
+        assert a.color == AssessmentColor.green
+        assert a.amber_reasons == []
+
+    def test_performance_1000_assessments(self) -> None:
+        assessments = [_make_assessment(confidence=0.5 if i % 2 == 0 else 0.9) for i in range(1000)]
+        start = time.perf_counter()
+        assign_colors(assessments)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 0.1  # 100 ms
+
+    def test_deterministic(self) -> None:
+        a1 = _make_assessment(confidence=0.45, position=Position.neutral)
+        a2 = _make_assessment(confidence=0.45, position=Position.neutral)
+        assign_colors([a1])
+        assign_colors([a2])
+        assert a1.color == a2.color
+        assert a1.amber_reasons == a2.amber_reasons
+        assert a1.effective_confidence == a2.effective_confidence
+
+
+class TestIsAmberBackwardCompat:
+    def test_color_amber_is_amber_true(self) -> None:
+        a = _make_assessment(confidence=0.3)
+        assign_colors([a])
+        assert a.color == AssessmentColor.amber
+        assert a.is_amber is True
+
+    def test_color_green_is_amber_false(self) -> None:
+        a = _make_assessment(confidence=0.85, position=Position.favorable)
+        assign_colors([a])
+        assert a.color == AssessmentColor.green
+        assert a.is_amber is False
+
+    def test_unassigned_color_still_works(self) -> None:
+        a = _make_assessment(confidence=0.3)
+        assert a.is_amber is False  # default before assign_colors
+        assign_colors([a])
+        assert a.is_amber is True  # set by assign_colors
+
+    def test_unassigned_color_green_no_amber(self) -> None:
+        a = _make_assessment(confidence=0.9)
+        assert a.is_amber is False  # not set by __post_init__
+
+    def test_color_red_is_amber_false(self) -> None:
+        a = _make_assessment(confidence=0.85, position=Position.unfavorable)
+        assign_colors([a])
+        assert a.color == AssessmentColor.red
+        assert a.is_amber is False
+
+
+class TestReviewSummaryExtensions:
+    def test_defaults(self) -> None:
+        s = ReviewSummary()
+        assert s.green_count == 0
+        assert s.red_count == 0
+        assert s.avg_effective_confidence == 0.0
+
+    def test_amber_count_preserved(self) -> None:
+        s = ReviewSummary(amber_count=5)
+        assert s.amber_count == 5
+
+    def test_with_values(self) -> None:
+        s = ReviewSummary(
+            favorable_count=10,
+            amber_count=3,
+            green_count=8,
+            red_count=2,
+            avg_effective_confidence=0.72,
+        )
+        assert s.green_count == 8
+        assert s.red_count == 2
+        assert s.avg_effective_confidence == 0.72
+
+
+class TestReviewReportExtensions:
+    def test_confidence_threshold_default(self) -> None:
+        r = ReviewReport(
+            document=None,  # type: ignore[arg-type]
+            assessments=[],
+            summary=ReviewSummary(),
+            playbook_id="test",
+            generated_at=None,  # type: ignore[arg-type]
+        )
+        assert r.confidence_threshold == 0.7
+
+    def test_confidence_threshold_custom(self) -> None:
+        r = ReviewReport(
+            document=None,  # type: ignore[arg-type]
+            assessments=[],
+            summary=ReviewSummary(),
+            playbook_id="test",
+            generated_at=None,  # type: ignore[arg-type]
+            confidence_threshold=0.9,
+        )
+        assert r.confidence_threshold == 0.9
+
+    def test_schema_version_bumped(self) -> None:
+        r = ReviewReport(
+            document=None,  # type: ignore[arg-type]
+            assessments=[],
+            summary=ReviewSummary(),
+            playbook_id="test",
+            generated_at=None,  # type: ignore[arg-type]
+        )
+        assert r.schema_version == "1.1.0"

--- a/tests/unit/test_three_color_report.py
+++ b/tests/unit/test_three_color_report.py
@@ -1,0 +1,306 @@
+"""Unit tests for three-color terminal and JSON report formatting."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from openreview_cli.review.colors import AssessmentColor, assign_colors
+from openreview_cli.review.models import (
+    ClauseAssessment,
+    DocMeta,
+    Position,
+    QAVerdict,
+    ReviewReport,
+    ReviewSummary,
+)
+from openreview_cli.review.report import format_json, format_terminal
+
+
+def _make_assessment(
+    cid: str,
+    pos: Position,
+    conf: float,
+    amber: bool = False,
+    error: str | None = None,
+    qa_verdict: QAVerdict = QAVerdict.agree,
+) -> ClauseAssessment:
+    ca = ClauseAssessment(
+        clause_id=cid,
+        clause_text=f"Clause {cid} text that is reasonably long enough to appear in reports.",
+        playbook_category="confidentiality-term",
+        position=pos,
+        confidence=conf,
+        citation=f"clause {cid} citation",
+        qa_verdict=qa_verdict,
+        extraction_model="m1",
+        qa_model="m1",
+        error=error,
+    )
+    if amber:
+        ca.is_amber = True
+    return ca
+
+
+def _make_report(assessments: list[ClauseAssessment] | None = None) -> ReviewReport:
+    if assessments is None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.85),
+            _make_assessment("c3", Position.unfavorable, 0.72, amber=True),
+            _make_assessment("c4", Position.uncertain, 0.45, amber=True),
+        ]
+    dm = DocMeta(
+        filename="nda.docx",
+        page_count=12,
+        clause_count=len(assessments),
+        pii_stripped=True,
+    )
+    green_count = sum(1 for a in assessments if a.color == AssessmentColor.green)
+    red_count = sum(1 for a in assessments if a.color == AssessmentColor.red)
+    valid_conf = [
+        a.effective_confidence
+        for a in assessments
+        if a.effective_confidence is not None and a.playbook_category != "no-match"
+    ]
+    avg_effective_confidence = sum(valid_conf) / len(valid_conf) if valid_conf else 0.0
+    summary = ReviewSummary(
+        favorable_count=sum(1 for a in assessments if a.position == Position.favorable),
+        neutral_count=sum(1 for a in assessments if a.position == Position.neutral),
+        unfavorable_count=sum(1 for a in assessments if a.position == Position.unfavorable),
+        uncertain_count=sum(1 for a in assessments if a.position == Position.uncertain),
+        no_match_count=0,
+        green_count=green_count,
+        red_count=red_count,
+        amber_count=sum(1 for a in assessments if a.color == AssessmentColor.amber),
+        avg_confidence=sum(a.confidence for a in assessments) / max(len(assessments), 1),
+        avg_effective_confidence=avg_effective_confidence,
+    )
+    return ReviewReport(
+        document=dm,
+        assessments=assessments,
+        summary=summary,
+        playbook_id="precheck-nda-v1",
+        generated_at=datetime.now(UTC),
+    )
+
+
+class TestFormatTerminalThreeColor:
+    def test_green_assessment_shows_green_badge(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "● OK" in output
+
+    def test_amber_assessment_shows_amber_badge(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "⚠" in output
+        assert "AMBER" in output
+
+    def test_red_assessment_shows_red_badge(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.unfavorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "● RED" in output
+
+    def test_amber_reason_breakdown_shown(self) -> None:
+        assessments = [
+            _make_assessment(
+                "c1",
+                Position.favorable,
+                0.45,
+                qa_verdict=QAVerdict.disagree,
+            ),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "low_confidence" in output or "Low confidence" in output
+        assert (
+            "Qa Disagreement" in output
+            or "qa_disagreement" in output
+            or "QA disagreement" in output
+        )
+
+    def test_multiple_amber_reasons_together(self) -> None:
+        assessments = [
+            _make_assessment(
+                "c1",
+                Position.favorable,
+                0.3,
+                error="LLM error",
+                qa_verdict=QAVerdict.disagree,
+            ),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "Error" in output
+        assert "low_confidence" in output or "Low confidence" in output
+
+    def test_green_assessment_no_amber_reasons_in_output(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "● OK" in output
+
+    def test_summary_shows_green_amber_red_counts(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.85),
+            _make_assessment("c3", Position.unfavorable, 0.95),
+            _make_assessment("c4", Position.favorable, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "Green:" in output
+        assert "Amber:" in output
+        assert "Red:" in output
+
+    def test_summary_shows_avg_effective_confidence(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.85),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "Avg effective confidence" in output
+
+    def test_summary_shows_confidence_threshold(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "Confidence threshold: 0.7" in output or "Confidence threshold" in output
+
+    def test_backward_compat_amber_flags_still_present(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "Amber flags" in output
+
+    def test_empty_assessments(self) -> None:
+        report = _make_report([])
+        output = format_terminal(report)
+        assert "No clauses to assess" in output
+
+    def test_no_grounding_no_grounding_triggers(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.favorable, 0.3),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        output = format_terminal(report)
+        assert "grounding" not in output.lower()
+
+
+class TestFormatJsonThreeColor:
+    def test_assessment_has_color_field(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.favorable, 0.3),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert data["assessments"][0]["color"] == "green"
+        assert data["assessments"][1]["color"] == "amber"
+
+    def test_assessment_has_amber_reasons_field(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.favorable, 0.3),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert data["assessments"][0]["amber_reasons"] == []
+        assert data["assessments"][1]["amber_reasons"] == ["low_confidence"]
+
+    def test_assessment_has_effective_confidence_field(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert data["assessments"][0]["effective_confidence"] == 0.92
+
+    def test_report_has_confidence_threshold(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert "confidence_threshold" in data
+        assert data["confidence_threshold"] == 0.7
+
+    def test_summary_has_green_red_avg_effective_counts(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.neutral, 0.85),
+            _make_assessment("c3", Position.unfavorable, 0.95),
+            _make_assessment("c4", Position.favorable, 0.45),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert data["summary"]["green_count"] == 2
+        assert data["summary"]["red_count"] == 1
+        assert isinstance(data["summary"]["avg_effective_confidence"], float)
+
+    def test_backward_compat_amber_count_present(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.3),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert "amber_count" in data["summary"]
+
+    def test_schema_version_1_1_0(self) -> None:
+        report = _make_report()
+        data = json.loads(format_json(report))
+        assert data["schema_version"] == "1.1.0"
+
+    def test_is_amber_consistent_with_color(self) -> None:
+        assessments = [
+            _make_assessment("c1", Position.favorable, 0.92),
+            _make_assessment("c2", Position.favorable, 0.3),
+        ]
+        assign_colors(assessments, threshold=0.7)
+        report = _make_report(assessments)
+        data = json.loads(format_json(report))
+        assert data["assessments"][0]["is_amber"] is False
+        assert data["assessments"][0]["color"] == "green"
+        assert data["assessments"][1]["is_amber"] is True
+        assert data["assessments"][1]["color"] == "amber"
+
+    def test_json_output_is_valid_json(self) -> None:
+        report = _make_report()
+        output = format_json(report)
+        data = json.loads(output)
+        assert isinstance(data, dict)


### PR DESCRIPTION
- AssessmentColor (Green/Amber/Red) and AmberReason enums
- User-configurable --confidence-threshold CLI flag (default 0.7)
- Confidence aggregation via min() across extraction, QA, grounding
- Three-color badges and amber reason breakdown in terminal output
- JSON output includes color, amber_reasons, effective_confidence
- is_amber as @property with _is_amber fallback for backward compat
- Schema version bumped to 1.1.0
- Accuracy ceiling disclosure in help text

Blueprint references: N-6, R-6, §6.4, CON-1